### PR TITLE
feat: Password 검증 API 구현

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -66,7 +66,16 @@ export const deleteStudy = asyncHandler(async (req, res) => {
 });
 
 export const verifyPassword = asyncHandler(async (req, res) => {
-  res.status(200).json({ message: "TODO" });
+  const { id } = req.params;
+  const { password } = req.body;
+  if (isNaN(id)) {
+    throw new BadRequestError("id는 숫자여야 합니다.");
+  }
+  const isCorrect = await studyService.verifyPassword(id, password); //boolean값을 리턴 받는다. true면 일치, false면 불일치.
+  if (!isCorrect) {
+    throw new BadRequestError("비밀번호가 올바르지 않습니다.");
+  }
+  res.status(200).json({ succss: true });
 });
 
 export const addEmoji = asyncHandler(async (req, res) => {

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -22,5 +22,15 @@ export const deleteStudy = async (id) => {
   });
   return res;
 };
-export const verifyPassword = async (id, password) => {};
+export const verifyPassword = async (id, password) => {
+  //prisma로, 해당하는 id의 스터디를 가져온다. (password필드만 셀렉해서 가져옴.)
+  const study = await prisma.study.findUniqueOrThrow({
+    where: { id: Number(id) },
+    select: { password: true },
+  });
+  //가져온 study의 password필드를 주어진 password와 비교한다.
+  const isCorrect = study.password === password;
+  //일치하는지에 대한 boolean값을 리턴함.
+  return isCorrect;
+};
 export const addEmoji = async (studyId, emoji) => {};


### PR DESCRIPTION
## 개요

사용자가 입력한 Password가 스터디의 Password와 일치하는지 검증하는 API 구현
`POST /studies/:id/verify-password`

## 변경 사항

- `study.controller.js` : verifyPassword 함수 구현. id 검증, service호출하여 password 일치 여부를 받아 성공/실패(에러) 응답.
- `study.service.js` : verifyPassword 함수 구현. prisma로 해당하는 id의 스터디를 가져와서, password가 일치하는지 검증.


## 관련 이슈

- close #10 
