### PR TITLE
feat: 오늘의 습관 체크/해제 API 구현

### DIFF
--- a/src/modules/habit/habit.controller.js
+++ b/src/modules/habit/habit.controller.js
@@ -21,7 +21,18 @@ export const createHabit = asyncHandler(async (req, res) => {
 });
 
 export const toggleHabit = asyncHandler(async (req, res) => {
-  res.status(200).json({ message: "TODO" });
+  const studyId = Number(req.params.studyId);
+  const habitId = Number(req.params.habitId);
+  const { completed } = req.body;
+  // 체크/해제 실제 처리(조회, 생성, 수정)는 service에 맡김
+  const toggleHabitLog = await habitService.toggleHabit(studyId, habitId, {
+    completed,
+  });
+
+  res.status(200).json({
+    success: true,
+    data: toggleHabitLog,
+  });
 });
 
 export const updateHabit = asyncHandler(async (req, res) => {

--- a/src/modules/habit/habit.routes.js
+++ b/src/modules/habit/habit.routes.js
@@ -5,7 +5,7 @@ const router = express.Router({ mergeParams: true });
 
 router.get("/today", habitController.getTodayHabits);
 router.post("/", habitController.createHabit);
-router.patch("/today/:habitId", habitController.toggleHabit);
+router.patch("/:habitId/today", habitController.toggleHabit);
 router.patch("/:habitId", habitController.updateHabit);
 router.delete("/:habitId", habitController.deleteHabit);
 

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -4,11 +4,21 @@ import {
   StudyNotFoundError,
 } from "../../errors/CustomError.js";
 
+// KST 기준 "오늘 날짜" 생성 (안 꼬이는 방식)
+const getTodayKST = () => {
+  const now = new Date();
+
+  // 한국 시간 기준으로 YYYY-MM-DD 문자열 만들기
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const dateStr = kst.toISOString().slice(0, 10);
+
+  // DB용 Date 객체 (날짜만 의미)
+  return new Date(dateStr);
+};
+
 export const getTodayHabits = async (studyId) => {
   // 오늘 날짜 (시간 제거)
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
+  const today = getTodayKST();
   const habits = await prisma.habit.findMany({
     where: {
       studyId: Number(studyId),
@@ -96,8 +106,7 @@ export const toggleHabit = async (studyId, habitId, data) => {
   }
 
   // 3. 오늘 날짜 생성 (시간 제거해서 날짜 기준으로 비교)
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const today = getTodayKST();
 
   // 4. 오늘 해당 habit의 로그가 이미 있는지 조회
   const existingLog = await prisma.habitLog.findUnique({
@@ -108,10 +117,7 @@ export const toggleHabit = async (studyId, habitId, data) => {
       },
     },
   });
-
-  // 현재 시각 (기록 시간용)
   const now = new Date();
-
   let result;
 
   // 5. 로그가 없으면 → 생성

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -65,7 +65,9 @@ export const createHabit = async (studyId, data) => {
   return newHabit;
 };
 
-export const toggleHabit = async (studyId, habitId, completed) => {};
+export const toggleHabit = async (studyId, habitId, data) => {
+  const { completed } = data;
+};
 export const updateHabit = async (studyId, habitId, data) => {};
 export const deleteHabit = async (studyId, habitId) => {};
 export const getWeeklyLogs = async (studyId, date) => {};

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -67,6 +67,77 @@ export const createHabit = async (studyId, data) => {
 
 export const toggleHabit = async (studyId, habitId, data) => {
   const { completed } = data;
+
+  // 1. 기본 값 검증
+  if (!studyId || Number.isNaN(studyId)) {
+    throw new BadRequestError("유효하지 않은 스터디 ID입니다.");
+  }
+
+  if (!habitId || Number.isNaN(habitId)) {
+    throw new BadRequestError("유효하지 않은 습관 ID입니다.");
+  }
+
+  // completed는 true/false만 허용
+  if (typeof completed !== "boolean") {
+    throw new BadRequestError("completed 값은 boolean이어야 합니다.");
+  }
+
+  // 2. 해당 habit이 존재하는지 + 해당 study에 속한 게 맞는지 확인
+  const habit = await prisma.habit.findFirst({
+    where: {
+      id: habitId,
+      studyId: studyId,
+    },
+  });
+
+  // 없으면 404 처리 (스터디 or 습관 없음)
+  if (!habit) {
+    throw new StudyNotFoundError();
+  }
+
+  // 3. 오늘 날짜 생성 (시간 제거해서 날짜 기준으로 비교)
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // 4. 오늘 해당 habit의 로그가 이미 있는지 조회
+  const existingLog = await prisma.habitLog.findUnique({
+    where: {
+      habitId_logDate: {
+        habitId,
+        logDate: today,
+      },
+    },
+  });
+
+  // 현재 시각 (기록 시간용)
+  const now = new Date();
+
+  let result;
+
+  // 5. 로그가 없으면 → 생성
+  if (!existingLog) {
+    result = await prisma.habitLog.create({
+      data: {
+        habitId,
+        logDate: today,
+        loggedAt: now,
+        completedAt: completed ? now : null,
+      },
+    });
+  } else {
+    // 6. 로그가 있으면 → completedAt만 수정
+    result = await prisma.habitLog.update({
+      where: {
+        id: existingLog.id,
+      },
+      data: {
+        completedAt: completed ? now : null,
+      },
+    });
+  }
+
+  // 7. controller로 결과 반환
+  return result;
 };
 export const updateHabit = async (studyId, habitId, data) => {};
 export const deleteHabit = async (studyId, habitId) => {};


### PR DESCRIPTION
## 개요
오늘의 습관 체크/해제 API를 구현했습니다.

## 변경 사항
- `PATCH /studies/:studyId/habits/:habitId/today` 엔드포인트 추가
- controller에서 `studyId`, `habitId`, `completed` 값을 받아 service로 전달하도록 구현
- service에서 다음 로직 구현
  - studyId, habitId, completed 값 검증
  - 해당 habit이 해당 study 소속인지 확인
  - 오늘 날짜 기준 habit log 조회
  - 오늘 로그가 없으면 생성, 있으면 수정
  - `completedAt` 값으로 체크/해제 처리
- `logDate`가 하루 밀리던 문제를 수정하여 날짜 기준 로직을 보완(이 부분 관련 자세한 수정 내용은 팀 노션에도 정리해두겠습니다.)

## 테스트
- Postman으로 체크 요청 테스트 완료
- Postman으로 해제 요청 테스트 완료
- DBeaver에서 `habit_logs` 테이블 반영 확인 완료

## 영향 범위
- `src/modules/habit/habit.routes.js`
- `src/modules/habit/habit.controller.js`
- `src/modules/habit/habit.service.js`

## 리뷰요청  
- `logDate` 날짜 처리 방식이 괜찮은지 확인 부탁드립니다.
## 관련 이슈
close #14