### PR TITLE
feat: 스터디 상세 조회 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -822,7 +821,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1396,7 +1396,6 @@
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1907,7 +1906,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2086,7 +2084,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.6.0",
         "@prisma/dev": "0.24.3",
@@ -2345,7 +2342,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -9,6 +9,16 @@ export const getStudies = asyncHandler(async (req, res) => {
   res.status(200).json({ message: "TODO" });
 });
 
+export const getStudyById = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+
+  if (!id) throw new BadRequestError("존재하지 않는 스터디입니다.");
+
+  const study = await studyService.getStudyById(id);
+
+  res.status(200).json({ success: true, data: study });
+});
+
 export const createStudy = asyncHandler(async (req, res) => {
   const { nickname, title, description, theme, password } = req.body;
 
@@ -29,10 +39,6 @@ export const createStudy = asyncHandler(async (req, res) => {
   });
 
   res.status(201).json({ success: true, data: createdStudy });
-});
-
-export const getStudyById = asyncHandler(async (req, res) => {
-  res.status(200).json({ message: "TODO" });
 });
 
 export const updateStudy = asyncHandler(async (req, res) => {

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -30,7 +30,11 @@ export const getStudyById = async (id) => {
           },
         },
       },
-      focusSessions: true,
+      focusSessions: {
+        select: {
+          earnedPoint: true,
+        },
+      },
       emojis: true,
     },
   });

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -31,6 +31,7 @@ export const getStudyById = async (id) => {
         },
       },
       focusSessions: {
+        where: { status: "completed" },
         select: {
           earnedPoint: true,
         },

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -1,6 +1,43 @@
 import prisma from "../../lib/prisma.js";
 
 export const getStudies = async () => {};
+
+export const getStudyById = async (id) => {
+  const today = new Date();
+  const day = today.getDay(); // 오늘이 속한 요일(숫자로 받음)
+  const monday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 월요일을 구함
+  monday.setDate(today.getDate() - (day === 0 ? 6 : day - 1));
+  monday.setHours(0, 0, 0, 0);
+
+  const sunday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 일요일을 구함
+  sunday.setDate(monday.getDate() + 6);
+  sunday.setHours(23, 59, 59, 999);
+
+  const res = prisma.study.findUniqueOrThrow({
+    where: { id: Number(id) },
+    omit: { password: true },
+    include: {
+      habits: {
+        include: {
+          // habitLogs 까지 가져와야함
+          habitLogs: {
+            where: {
+              logDate: {
+                gte: monday,
+                lte: sunday,
+              },
+            },
+          },
+        },
+      },
+      focusSessions: true,
+      emojis: true,
+    },
+  });
+
+  return res;
+};
+
 export const createStudy = async (data) => {
   console.log("연결 주소 확인:", process.env.DATABASE_URL);
   const res = await prisma.study.create({
@@ -8,7 +45,7 @@ export const createStudy = async (data) => {
   });
   return res;
 };
-export const getStudyById = async (id) => {};
+
 export const updateStudy = async (id, data) => {
   const res = await prisma.study.update({
     where: { id: Number(id) },
@@ -16,12 +53,14 @@ export const updateStudy = async (id, data) => {
   });
   return res;
 };
+
 export const deleteStudy = async (id) => {
   const res = await prisma.study.delete({
     where: { id: Number(id) },
   });
   return res;
 };
+
 export const verifyPassword = async (id, password) => {
   //prisma로, 해당하는 id의 스터디를 가져온다. (password필드만 셀렉해서 가져옴.)
   const study = await prisma.study.findUniqueOrThrow({
@@ -33,4 +72,5 @@ export const verifyPassword = async (id, password) => {
   //일치하는지에 대한 boolean값을 리턴함.
   return isCorrect;
 };
+
 export const addEmoji = async (studyId, emoji) => {};


### PR DESCRIPTION
## 개요

스터디 상세 페이지 접속시 path parameter 로 전달받은 id 값을 가지고 스터디(study) 테이블의 id 와 매칭된 데이터를 응답

해당 스터디와 참조된 집중(focusSessions), 습관(habits, habitLogs), 이모지(emojis) 테이블의 데이터들을 include

오늘 날짜를 기준으로 이번주의 시작인 월요일의 날짜와 끝인 일요일의 날짜를 구해서 습관 데이터를 가져올 때 이번 주 데이터만 가져올 수 있게 쿼리 구현

포인트는 status 가 completed 인 데이터에서 earnedPoint 필드만 가져오도록 처리 - 다른 데이터는 불필요함

## 코드리뷰
구현된 방식은 오늘 날짜를 기준으로 이번 주 기간을 구하고, 습관 기록표에 출력할 습관 데이터를 구해놓은 기간 범위내의 데이터만 가져와서 전달하게 구현을 했는데

이건 백에서 조회 조건 처리해서 원하는 만큼의 데이터를 주는게 맞는지, 전체 데이터를 주고 프론트에서 오늘 날짜를 기준으로 범위 기간을 구해서 filtering 을 하는게 맞는지 궁금합니다

## 관련 이슈

- close #18 
