### PR TITLE
feat: 공통 validateId 미들웨어 추가

### DIFF
--- a/prisma/migrations/20260416051907_remove_emojis_unique/migration.sql
+++ b/prisma/migrations/20260416051907_remove_emojis_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "emojis_study_id_emoji_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,5 @@ model Emoji {
 
   study     Study    @relation(fields: [studyId], references: [id], onDelete: Cascade)
 
-  @@unique([studyId, emoji])
   @@map("emojis")
 }

--- a/src/common/middlewares/validateId.js
+++ b/src/common/middlewares/validateId.js
@@ -1,0 +1,17 @@
+import { BadRequestError } from "../errors/CustomError.js";
+
+const PARAM_LABEL = {
+  studyId: "스터디 ID",
+  habitId: "습관 ID",
+  sessionId: "집중 세션 ID",
+};
+
+export const validateId = (req, res, next, value, name) => {
+  const id = Number(value);
+  if (!Number.isInteger(id) || id <= 0) {
+    const label = PARAM_LABEL[name] ?? name;
+    return next(new BadRequestError(`${label}는 양의 정수여야 합니다`));
+  }
+  req.params[name] = id;
+  next();
+};

--- a/src/common/middlewares/validateId.js
+++ b/src/common/middlewares/validateId.js
@@ -1,4 +1,4 @@
-import { BadRequestError } from "../errors/CustomError.js";
+import { BadRequestError } from "../../errors/CustomError.js";
 
 const PARAM_LABEL = {
   studyId: "스터디 ID",

--- a/src/modules/focus/focus.routes.js
+++ b/src/modules/focus/focus.routes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { validateId } from "../middlewares/validateId.js";
+import { validateId } from "../../common/middlewares/validateId.js";
 import * as focusController from "./focus.controller.js";
 
 const router = express.Router({ mergeParams: true });

--- a/src/modules/focus/focus.routes.js
+++ b/src/modules/focus/focus.routes.js
@@ -1,7 +1,11 @@
 import express from "express";
+import { validateId } from "../middlewares/validateId.js";
 import * as focusController from "./focus.controller.js";
 
 const router = express.Router({ mergeParams: true });
+
+router.param("studyId", validateId);
+router.param("sessionId", validateId);
 
 router.get("/", focusController.getSession);
 router.post("/", focusController.createSession);

--- a/src/modules/habit/habit-log.routes.js
+++ b/src/modules/habit/habit-log.routes.js
@@ -1,7 +1,10 @@
 import express from "express";
+import { validateId } from "../middlewares/validateId.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });
+
+router.param("studyId", validateId);
 
 router.get("/", habitController.getWeeklyLogs); // ?date=YYYY-MM-DD
 

--- a/src/modules/habit/habit-log.routes.js
+++ b/src/modules/habit/habit-log.routes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { validateId } from "../middlewares/validateId.js";
+import { validateId } from "../../common/middlewares/validateId.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });

--- a/src/modules/habit/habit.routes.js
+++ b/src/modules/habit/habit.routes.js
@@ -1,7 +1,11 @@
 import express from "express";
+import { validateId } from "../middlewares/validateId.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });
+
+router.param("studyId", validateId);
+router.param("habitId", validateId);
 
 router.get("/today", habitController.getTodayHabits);
 router.post("/", habitController.createHabit);

--- a/src/modules/habit/habit.routes.js
+++ b/src/modules/habit/habit.routes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { validateId } from "../middlewares/validateId.js";
+import { validateId } from "../../common/middlewares/validateId.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });

--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -10,11 +10,11 @@ export const getStudies = asyncHandler(async (req, res) => {
 });
 
 export const getStudyById = asyncHandler(async (req, res) => {
-  const { id } = req.params;
+  const { studyId } = req.params;
 
-  if (!id) throw new BadRequestError("존재하지 않는 스터디입니다.");
+  if (!studyId) throw new BadRequestError("존재하지 않는 스터디입니다.");
 
-  const study = await studyService.getStudyById(id);
+  const study = await studyService.getStudyById(studyId);
 
   res.status(200).json({ success: true, data: study });
 });
@@ -24,12 +24,11 @@ export const createStudy = asyncHandler(async (req, res) => {
 
   //에러 핸들링 (validation)
   if (!title || !theme || !password || !nickname) {
-    //TODO:  description항목은 사용자가 작성하지 않아도 되는거라..얘 기본값 주는 걸 어디서 할지 의논이 필요할 것 같기도? 아니면 그냥 일단 null값으로넣어야 할까. 그래야겠다.
     throw new BadRequestError(
       "스터디 생성에 실패했습니다. 닉네임, 제목, 테마, 비밀번호는 필수입니다.",
-    ); //원래는 앞 문장만 정해뒀었는데 혹시모르니 뒤에 문장도 적어둠..
-    //이게 400에러를 반환하는데, 500에러는 알아서 처리되는 거겠지?
+    );
   }
+
   const createdStudy = await studyService.createStudy({
     nickname,
     title,
@@ -42,19 +41,20 @@ export const createStudy = asyncHandler(async (req, res) => {
 });
 
 export const updateStudy = asyncHandler(async (req, res) => {
-  const { id } = req.params;
+  const { studyId } = req.params;
   const { title, description, theme, password, nickname } = req.body;
-  if (isNaN(id)) {
-    //이건 api 명세서엔 작성 안되었던건데, delete엔 했으므로 얘도 일단 해줌.. TODO: api명세서 오류 파트에 id숫자 검증 작성하기
+
+  if (isNaN(studyId)) {
     throw new BadRequestError("id는 숫자여야 합니다.");
   }
+
   if (!title || !theme || !password || !nickname) {
     throw new BadRequestError(
       "스터디 수정에 실패했습니다. 유효하지 않은 입력값입니다.",
     );
   }
-  //id 검증은 프리즈마에서 알아서 해준다고 함!
-  const updatedStudy = await studyService.updateStudy(id, {
+
+  const updatedStudy = await studyService.updateStudy(studyId, {
     title,
     description,
     theme,
@@ -65,22 +65,22 @@ export const updateStudy = asyncHandler(async (req, res) => {
 });
 
 export const deleteStudy = asyncHandler(async (req, res) => {
-  const { id } = req.params;
-  if (isNaN(id)) {
+  const { studyId } = req.params;
+  if (isNaN(studyId)) {
     throw new BadRequestError("id는 숫자여야 합니다.");
   }
-  await studyService.deleteStudy(id);
+  await studyService.deleteStudy(studyId);
 
   res.status(204).send();
 });
 
 export const verifyPassword = asyncHandler(async (req, res) => {
-  const { id } = req.params;
+  const { studyId } = req.params;
   const { password } = req.body;
-  if (isNaN(id)) {
+  if (isNaN(studyId)) {
     throw new BadRequestError("id는 숫자여야 합니다.");
   }
-  const isCorrect = await studyService.verifyPassword(id, password); //boolean값을 리턴 받는다. true면 일치, false면 불일치.
+  const isCorrect = await studyService.verifyPassword(studyId, password); //boolean값을 리턴 받는다. true면 일치, false면 불일치.
   if (!isCorrect) {
     throw new BadRequestError("비밀번호가 올바르지 않습니다.");
   }
@@ -90,8 +90,8 @@ export const verifyPassword = asyncHandler(async (req, res) => {
     req.session.authorizedStudies = [];
   }
   //비밀번호가 일치할 시, 현재 스터디 id를, 세션 배열에 추가
-  if (!req.session.authorizedStudies.includes(Number(id))) {
-    req.session.authorizedStudies.push(Number(id));
+  if (!req.session.authorizedStudies.includes(Number(studyId))) {
+    req.session.authorizedStudies.push(Number(studyId));
   }
   res
     .status(200)
@@ -100,8 +100,8 @@ export const verifyPassword = asyncHandler(async (req, res) => {
 
 //세션에 있는 스터디 id인지 점검
 export const checkSession = asyncHandler(async (req, res) => {
-  const { id } = req.params;
-  const isAuthorized = req.session.authorizedStudies?.includes(Number(id));
+  const { studyId } = req.params;
+  const isAuthorized = req.session.authorizedStudies?.includes(Number(studyId));
   if (!isAuthorized) {
     //세션에 없는 스터디 id 일시, 에러를 리턴한다. (그런데 그냥 응답으로 주는 게 프론트가 편하다는데, 뭐가 좋을까?)
     throw new AuthenticationError();

--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -12,8 +12,6 @@ export const getStudies = asyncHandler(async (req, res) => {
 export const getStudyById = asyncHandler(async (req, res) => {
   const { studyId } = req.params;
 
-  if (!studyId) throw new BadRequestError("존재하지 않는 스터디입니다.");
-
   const study = await studyService.getStudyById(studyId);
 
   res.status(200).json({ success: true, data: study });
@@ -44,10 +42,6 @@ export const updateStudy = asyncHandler(async (req, res) => {
   const { studyId } = req.params;
   const { title, description, theme, password, nickname } = req.body;
 
-  if (isNaN(studyId)) {
-    throw new BadRequestError("id는 숫자여야 합니다.");
-  }
-
   if (!title || !theme || !password || !nickname) {
     throw new BadRequestError(
       "스터디 수정에 실패했습니다. 유효하지 않은 입력값입니다.",
@@ -61,14 +55,13 @@ export const updateStudy = asyncHandler(async (req, res) => {
     password,
     nickname,
   });
+
   res.status(200).json({ success: true, data: updatedStudy });
 });
 
 export const deleteStudy = asyncHandler(async (req, res) => {
   const { studyId } = req.params;
-  if (isNaN(studyId)) {
-    throw new BadRequestError("id는 숫자여야 합니다.");
-  }
+
   await studyService.deleteStudy(studyId);
 
   res.status(204).send();
@@ -77,10 +70,9 @@ export const deleteStudy = asyncHandler(async (req, res) => {
 export const verifyPassword = asyncHandler(async (req, res) => {
   const { studyId } = req.params;
   const { password } = req.body;
-  if (isNaN(studyId)) {
-    throw new BadRequestError("id는 숫자여야 합니다.");
-  }
+
   const isCorrect = await studyService.verifyPassword(studyId, password); //boolean값을 리턴 받는다. true면 일치, false면 불일치.
+
   if (!isCorrect) {
     throw new BadRequestError("비밀번호가 올바르지 않습니다.");
   }
@@ -90,8 +82,8 @@ export const verifyPassword = asyncHandler(async (req, res) => {
     req.session.authorizedStudies = [];
   }
   //비밀번호가 일치할 시, 현재 스터디 id를, 세션 배열에 추가
-  if (!req.session.authorizedStudies.includes(Number(studyId))) {
-    req.session.authorizedStudies.push(Number(studyId));
+  if (!req.session.authorizedStudies.includes(studyId)) {
+    req.session.authorizedStudies.push(studyId);
   }
   res
     .status(200)
@@ -101,7 +93,7 @@ export const verifyPassword = asyncHandler(async (req, res) => {
 //세션에 있는 스터디 id인지 점검
 export const checkSession = asyncHandler(async (req, res) => {
   const { studyId } = req.params;
-  const isAuthorized = req.session.authorizedStudies?.includes(Number(studyId));
+  const isAuthorized = req.session.authorizedStudies?.includes(studyId);
   if (!isAuthorized) {
     //세션에 없는 스터디 id 일시, 에러를 리턴한다. (그런데 그냥 응답으로 주는 게 프론트가 편하다는데, 뭐가 좋을까?)
     throw new AuthenticationError();

--- a/src/modules/study/study.routes.js
+++ b/src/modules/study/study.routes.js
@@ -1,7 +1,10 @@
 import express from "express";
+import { validateId } from "../middlewares/validateId.js";
 import * as studyController from "./study.controller.js";
 
 const router = express.Router();
+
+router.param("studyId", validateId);
 
 router.get("/", studyController.getStudies);
 router.post("/", studyController.createStudy);

--- a/src/modules/study/study.routes.js
+++ b/src/modules/study/study.routes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { validateId } from "../middlewares/validateId.js";
+import { validateId } from "../../common/middlewares/validateId.js";
 import * as studyController from "./study.controller.js";
 
 const router = express.Router();

--- a/src/modules/study/study.routes.js
+++ b/src/modules/study/study.routes.js
@@ -5,11 +5,11 @@ const router = express.Router();
 
 router.get("/", studyController.getStudies);
 router.post("/", studyController.createStudy);
-router.get("/:id", studyController.getStudyById);
-router.patch("/:id", studyController.updateStudy);
-router.delete("/:id", studyController.deleteStudy);
-router.post("/:id/verify-password", studyController.verifyPassword);
-router.get("/:id/check-session", studyController.checkSession);
-router.post("/:id/emojis", studyController.addEmoji);
+router.get("/:studyId", studyController.getStudyById);
+router.patch("/:studyId", studyController.updateStudy);
+router.delete("/:studyId", studyController.deleteStudy);
+router.post("/:studyId/verify-password", studyController.verifyPassword);
+router.get("/:studyId/check-session", studyController.checkSession);
+router.post("/:studyId/emojis", studyController.addEmoji);
 
 export default router;

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -14,7 +14,7 @@ export const getStudyById = async (id) => {
   sunday.setHours(23, 59, 59, 999);
 
   const res = prisma.study.findUniqueOrThrow({
-    where: { id: Number(id) },
+    where: { id },
     omit: { password: true },
     include: {
       habits: {
@@ -53,7 +53,7 @@ export const createStudy = async (data) => {
 
 export const updateStudy = async (id, data) => {
   const res = await prisma.study.update({
-    where: { id: Number(id) },
+    where: { id },
     data,
   });
   return res;
@@ -61,7 +61,7 @@ export const updateStudy = async (id, data) => {
 
 export const deleteStudy = async (id) => {
   const res = await prisma.study.delete({
-    where: { id: Number(id) },
+    where: { id },
   });
   return res;
 };
@@ -69,7 +69,7 @@ export const deleteStudy = async (id) => {
 export const verifyPassword = async (id, password) => {
   //prisma로, 해당하는 id의 스터디를 가져온다. (password필드만 셀렉해서 가져옴.)
   const study = await prisma.study.findUniqueOrThrow({
-    where: { id: Number(id) },
+    where: { id },
     select: { password: true },
   });
   //가져온 study의 password필드를 주어진 password와 비교한다.


### PR DESCRIPTION
## 개요
컨트롤러 및 서비스에 중복으로 존재하던 path parameter  ID 검증 로직(Number 변환, isNaN 체크 등)을 공통 미들웨어(validateId)로 통합했습니다.
이를 통해 ID 검증 정책의 일관성을 확보하고, 각 도메인(study, habit, habit-log, focus)에서 중복 코드 없이 안정적으로 ID를 처리할 수 있도록 개선했습니다.

## 변경 사항
- validateId 공통 미들웨어 구현 (`common/middlewares/validateId.js`)
- study / habit / focus 라우터에 `router.param()` 적용
- study 도메인 파라미터명 `id → studyId` 통일 (routes / controller)
- study 컨트롤러 및 서비스 내 중복 ID 검증 로직 제거
   - habit, habit-log, focus는 이후 study 존재 여부 검증 미들웨어 적용 시 함께 정리할 예정입니다.

## 영향 범위
- 모든 path parameter 기반 API의 ID 처리 방식 변경
- 기존 컨트롤러에서 수행하던 `Number(id)` / `isNaN` 검증 로직 제거
- ID 검증 실패 시 validateId 미들웨어에서 즉시 에러 처리

## 관련 이슈
- close #24
