### PR TITLE
feat: 습관 삭제 API 구현

### DIFF
--- a/src/modules/habit/habit.controller.js
+++ b/src/modules/habit/habit.controller.js
@@ -24,7 +24,7 @@ export const toggleHabit = asyncHandler(async (req, res) => {
   const studyId = Number(req.params.studyId);
   const habitId = Number(req.params.habitId);
   const { completed } = req.body;
-  // 체크/해제 실제 처리(조회, 생성, 수정)는 service에 맡김
+
   const toggleHabitLog = await habitService.toggleHabit(studyId, habitId, {
     completed,
   });
@@ -53,6 +53,9 @@ export const updateHabit = asyncHandler(async (req, res) => {
 });
 
 export const deleteHabit = asyncHandler(async (req, res) => {
+  const { studyId, habitId } = req.params;
+  await habitService.deleteHabit(studyId, habitId);
+
   res.status(204).send();
 });
 

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -2,6 +2,7 @@ import prisma from "../../lib/prisma.js";
 import {
   BadRequestError,
   StudyNotFoundError,
+  HabitNotFoundError,
 } from "../../errors/CustomError.js";
 
 // KST 기준 "오늘 날짜" 생성 (안 꼬이는 방식)
@@ -217,5 +218,36 @@ export const updateHabit = async (studyId, habitId, data) => {
 
   return updatedHabit;
 };
-export const deleteHabit = async (studyId, habitId) => {};
+
+export const deleteHabit = async (studyId, habitId) => {
+  // 1. 해당 스터디에 속한 습관이 실제로 존재하는지 확인
+  const habit = await prisma.habit.findFirst({
+    where: {
+      id: habitId,
+      studyId,
+    },
+  });
+
+  // 2. 없으면 습관 없음 에러
+  //    - 스터디가 없거나, 해당 스터디에 이 습관이 없거나
+  if (!habit) {
+    throw new HabitNotFoundError();
+  }
+
+  // 3. 이미 종료된 습관이면 다시 삭제할 수 없도록 막기
+  if (habit.endAt !== null) {
+    throw new BadRequestError("이미 종료된 습관은 삭제할 수 없습니다.");
+  }
+
+  // 4. 실제 삭제 대신 endAt을 현재 시각으로 설정해서 종료 처리(soft delete)
+  await prisma.habit.update({
+    where: {
+      id: habitId,
+    },
+    data: {
+      endAt: new Date(),
+    },
+  });
+};
+
 export const getWeeklyLogs = async (studyId, date) => {};

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -224,7 +224,7 @@ export const deleteHabit = async (studyId, habitId) => {
   const habit = await prisma.habit.findFirst({
     where: {
       id: habitId,
-      studyId,
+      studyId: Number(studyId),
     },
   });
 


### PR DESCRIPTION
## 개요

스터디에 속한 습관을 삭제(soft delete)하는 API를 구현했습니다.
삭제 요청 시 실제로 데이터를 제거하지 않고, endAt 필드를 설정하여 종료 처리합니다.

## 변경 사항

- DELETE /studies/:studyId/habits/:habitId API 구현
- soft delete 방식 적용 (endAt 설정)
- 해당 스터디에 속한 습관인지 검증
- 이미 종료된 습관은 삭제 불가 처리
- HabitNotFoundError를 통한 에러 처리 적용
- studyId 타입 오류(Number 변환) 수정

## 영향 범위

- habits 테이블의 endAt 필드 사용


## 테스트
- 정상 삭제 시 204 No Content 반환 확인
- DB에서 endAt 값이 설정되는 것 확인

## 관련 이슈

- close #28 
