### PR TITLE
refactor: 부모 리소스(study) 존재 여부 검증 미들웨어 추가 

### DIFF
--- a/src/common/middlewares/studyExist.js
+++ b/src/common/middlewares/studyExist.js
@@ -1,5 +1,8 @@
 import prisma from "../../lib/prisma.js";
-import { StudyNotFoundError } from "../../errors/CustomError.js";
+import {
+  BadRequestError,
+  StudyNotFoundError,
+} from "../../errors/CustomError.js";
 
 export const checkStudyExists = async (req, res, next) => {
   const studyId = Number(req.params.studyId);

--- a/src/common/middlewares/studyExist.js
+++ b/src/common/middlewares/studyExist.js
@@ -1,0 +1,17 @@
+import prisma from "../../lib/prisma.js";
+import { StudyNotFoundError } from "../../errors/CustomError.js";
+
+export const checkStudyExists = async (req, res, next) => {
+  const studyId = req.params.studyId;
+
+  const study = await prisma.study.findUnique({
+    where: { id: studyId },
+    select: { id: true },
+  });
+
+  if (!study) {
+    return next(new StudyNotFoundError());
+  }
+
+  next();
+};

--- a/src/common/middlewares/studyExist.js
+++ b/src/common/middlewares/studyExist.js
@@ -2,7 +2,11 @@ import prisma from "../../lib/prisma.js";
 import { StudyNotFoundError } from "../../errors/CustomError.js";
 
 export const checkStudyExists = async (req, res, next) => {
-  const studyId = req.params.studyId;
+  const studyId = Number(req.params.studyId);
+
+  if (!Number.isInteger(studyId) || studyId <= 0) {
+    return next(new BadRequestError("스터디 ID가 올바르지 않습니다"));
+  }
 
   const study = await prisma.study.findUnique({
     where: { id: studyId },
@@ -13,5 +17,6 @@ export const checkStudyExists = async (req, res, next) => {
     return next(new StudyNotFoundError());
   }
 
+  req.studyId = studyId;
   next();
 };

--- a/src/modules/focus/focus.controller.js
+++ b/src/modules/focus/focus.controller.js
@@ -6,11 +6,15 @@ import * as focusService from "./focus.service.js";
 import asyncHandler from "../../common/middlewares/asyncHandler.js";
 
 export const getSession = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
+  const studyId = req.studyId;
   const focus = await focusService.getSession(studyId);
 
-  if (!focus)
-    throw new FocusNotFoundError("해당 studyId로 등록된 데이터 미존재");
+  if (!focus) {
+    return res.status(200).json({
+      success: true,
+      data: null,
+    });
+  }
 
   if (focus.status === "completed") {
     return res.status(200).json({
@@ -26,10 +30,9 @@ export const getSession = asyncHandler(async (req, res) => {
 });
 
 export const createSession = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
-  const durationMin = Number(req.body.durationMin);
+  const studyId = req.studyId;
+  const durationMin = req.body.durationMin;
 
-  if (!studyId) throw new BadRequestError("studyId 데이터 넘어오지 않음");
   if (!durationMin || durationMin <= 0)
     throw new BadRequestError("durationMin 데이터 오류");
 

--- a/src/modules/focus/focus.routes.js
+++ b/src/modules/focus/focus.routes.js
@@ -1,11 +1,14 @@
 import express from "express";
 import { validateId } from "../../common/middlewares/validateId.js";
+import { checkStudyExists } from "../../common/middlewares/studyExist.js";
 import * as focusController from "./focus.controller.js";
 
 const router = express.Router({ mergeParams: true });
 
 router.param("studyId", validateId);
 router.param("sessionId", validateId);
+
+router.use(checkStudyExists);
 
 router.get("/", focusController.getSession);
 router.post("/", focusController.createSession);

--- a/src/modules/focus/focus.service.js
+++ b/src/modules/focus/focus.service.js
@@ -4,7 +4,7 @@ import { StudyNotFoundError, ConflictError } from "../../errors/CustomError.js";
 export const getSession = async (studyId) => {
   const focus = await prisma.FocusSession.findFirst({
     where: {
-      studyId: studyId,
+      studyId,
     },
     select: {
       id: true,
@@ -26,20 +26,12 @@ export const getSession = async (studyId) => {
 
   return focus;
 };
+
 export const createSession = async (studyId, durationMin) => {
-  // 해당 스터디가 존재하는지 체크
-  const study = await prisma.study.findUnique({
-    where: { id: studyId },
-  });
-
-  if (!study) {
-    throw new StudyNotFoundError();
-  }
-
   // 현재 진행중인 집중이 있는지 확인
   const focus = await prisma.FocusSession.findFirst({
     where: {
-      studyId: studyId,
+      studyId,
       status: {
         in: ["running", "paused"],
       },
@@ -54,10 +46,10 @@ export const createSession = async (studyId, durationMin) => {
 
   const newFocus = await prisma.FocusSession.create({
     data: {
-      studyId: studyId,
-      durationMin: durationMin,
+      studyId,
+      durationMin,
       status: "running",
-      endTime: endTime,
+      endTime,
     },
   });
 

--- a/src/modules/habit/habit-log.routes.js
+++ b/src/modules/habit/habit-log.routes.js
@@ -1,10 +1,14 @@
 import express from "express";
 import { validateId } from "../../common/middlewares/validateId.js";
+import { checkStudyExists } from "../../common/middlewares/studyExist.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });
 
 router.param("studyId", validateId);
+router.param("habitId", validateId);
+
+router.use(checkStudyExists);
 
 router.get("/", habitController.getWeeklyLogs); // ?date=YYYY-MM-DD
 

--- a/src/modules/habit/habit.controller.js
+++ b/src/modules/habit/habit.controller.js
@@ -2,13 +2,13 @@ import * as habitService from "./habit.service.js";
 import asyncHandler from "../../common/middlewares/asyncHandler.js";
 
 export const getTodayHabits = asyncHandler(async (req, res) => {
-  const { studyId } = req.params;
+  const studyId = req.studyId;
   const habits = await habitService.getTodayHabits(studyId);
   res.status(200).json(habits);
 });
 
 export const createHabit = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
+  const studyId = req.studyId;
   const { habitName } = req.body;
   const newHabit = await habitService.createHabit(studyId, {
     habitName,
@@ -21,8 +21,9 @@ export const createHabit = asyncHandler(async (req, res) => {
 });
 
 export const toggleHabit = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
-  const habitId = Number(req.params.habitId);
+  const studyId = req.studyId;
+  const habitId = req.params.habitId;
+
   const { completed } = req.body;
 
   const toggleHabitLog = await habitService.toggleHabit(studyId, habitId, {
@@ -36,8 +37,8 @@ export const toggleHabit = asyncHandler(async (req, res) => {
 });
 
 export const updateHabit = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
-  const habitId = Number(req.params.habitId);
+  const studyId = req.studyId;
+  const habitId = req.params.habitId;
 
   const { habitName, startAt } = req.body;
 
@@ -53,7 +54,9 @@ export const updateHabit = asyncHandler(async (req, res) => {
 });
 
 export const deleteHabit = asyncHandler(async (req, res) => {
-  const { studyId, habitId } = req.params;
+  const studyId = req.studyId;
+  const habitId = req.params.habitId;
+
   await habitService.deleteHabit(studyId, habitId);
 
   res.status(204).send();

--- a/src/modules/habit/habit.routes.js
+++ b/src/modules/habit/habit.routes.js
@@ -1,11 +1,14 @@
 import express from "express";
 import { validateId } from "../../common/middlewares/validateId.js";
+import { checkStudyExists } from "../../common/middlewares/studyExist.js";
 import * as habitController from "./habit.controller.js";
 
 const router = express.Router({ mergeParams: true });
 
 router.param("studyId", validateId);
 router.param("habitId", validateId);
+
+router.use(checkStudyExists);
 
 router.get("/today", habitController.getTodayHabits);
 router.post("/", habitController.createHabit);

--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -22,7 +22,7 @@ export const getTodayHabits = async (studyId) => {
   const today = getTodayKST();
   const habits = await prisma.habit.findMany({
     where: {
-      studyId: Number(studyId),
+      studyId,
       startAt: { lte: today },
       OR: [{ endAt: null }, { endAt: { gte: today } }],
     },
@@ -45,26 +45,12 @@ export const getTodayHabits = async (studyId) => {
 export const createHabit = async (studyId, data) => {
   const { habitName } = data;
 
-  // 1. studyId 검증
-  if (!studyId || Number.isNaN(studyId)) {
-    throw new BadRequestError("유효하지 않은 스터디 ID입니다.");
-  }
-
-  // 2. habitName 검증
+  // 1. habitName 검증
   if (!habitName || !habitName.trim()) {
     throw new BadRequestError("습관 이름은 필수입니다.");
   }
 
-  // 3. study 존재 여부 확인
-  const study = await prisma.study.findUnique({
-    where: { id: studyId },
-  });
-
-  if (!study) {
-    throw new StudyNotFoundError();
-  }
-
-  // 4. 생성
+  // 2. 생성
   const newHabit = await prisma.habit.create({
     data: {
       studyId,
@@ -80,14 +66,6 @@ export const toggleHabit = async (studyId, habitId, data) => {
   const { completed } = data;
 
   // 1. 기본 값 검증
-  if (!studyId || Number.isNaN(studyId)) {
-    throw new BadRequestError("유효하지 않은 스터디 ID입니다.");
-  }
-
-  if (!habitId || Number.isNaN(habitId)) {
-    throw new BadRequestError("유효하지 않은 습관 ID입니다.");
-  }
-
   // completed는 true/false만 허용
   if (typeof completed !== "boolean") {
     throw new BadRequestError("completed 값은 boolean이어야 합니다.");
@@ -103,7 +81,7 @@ export const toggleHabit = async (studyId, habitId, data) => {
 
   // 없으면 404 처리 (스터디 or 습관 없음)
   if (!habit) {
-    throw new StudyNotFoundError();
+    throw new HabitNotFoundError();
   }
 
   // 3. 오늘 날짜 생성 (시간 제거해서 날짜 기준으로 비교)
@@ -149,14 +127,6 @@ export const toggleHabit = async (studyId, habitId, data) => {
 
 export const updateHabit = async (studyId, habitId, data) => {
   const { habitName, startAt } = data;
-
-  if (!studyId || Number.isNaN(studyId)) {
-    throw new BadRequestError("유효하지 않은 스터디 ID입니다.");
-  }
-
-  if (!habitId || Number.isNaN(habitId)) {
-    throw new BadRequestError("유효하지 않은 습관 ID입니다.");
-  }
 
   // 수정할 값이 없으면 잘못된 요청
   const hasHabitName = habitName !== undefined;


### PR DESCRIPTION
## 개요
부모 리소스(study) 존재 여부 검증 로직을 공통 미들웨어로 분리했습니다.
이를 통해 중복 코드를 제거하고, 하위 리소스(habit, habitLog, focus) 요청 처리 전에 study 존재 여부를 일관되게 검증하도록 구조를 개선했습니다.
또한 controller/service 레이어에서는 study 검증 로직을 제거하여 각 도메인의 비즈니스 로직만 담당하도록 책임을 분리했습니다.

## 변경 사항
- `checkStudyExists` 미들웨어 추가
- habit / habitLog / focus 라우터에 `router.use()` 적용
- controller에서 `req.params.studyId` 대신 `req.studyId` 사용하도록 수정
- service 레이어의 중복 study 존재 검증 로직 제거
- controller, service 레이어의 불필요한 Number(studyId) 변환 제거
- 하위 리소스 요청 시 부모 리소스 미존재 → STUDY_NOT_FOUND 반환하도록 수정

## 영향 범위
- 하위 리소스 API에서 부모 리소스 미존재 시 404 응답으로 통일
- habit, habitLog, focus 라우터 파일 변경 
- habit과 focus의 controller/service 레이어 구조 변경 (study 존재 여부 검증 및 id 형식 검증 로직 제거)

## 관련 이슈
- close #27
