### PR TITLE
refactor: focus controller에서 불필요한 Number 변환 제거

### DIFF
--- a/src/modules/focus/focus.controller.js
+++ b/src/modules/focus/focus.controller.js
@@ -47,15 +47,18 @@ export const createSession = asyncHandler(async (req, res) => {
 
 // 오늘의 집중 상태 변경
 export const updateSession = asyncHandler(async (req, res) => {
-  const studyId = Number(req.params.studyId);
-
-  // req.params.id로 넘어올 줄 알았는데 해당 값은 sessionId로 넘어옴
-  const id = Number(req.params.sessionId);
+  const studyId = req.studyId;
+  const sessionId = req.params.sessionId;
   const action = req.body.action;
 
-  if (!studyId || !id || !action) throw new BadRequestError("필수 데이터 누락");
+  if (!studyId || !sessionId || !action)
+    throw new BadRequestError("필수 데이터 누락");
 
-  const updateFocus = await focusService.updateSession(studyId, id, action);
+  const updateFocus = await focusService.updateSession(
+    studyId,
+    sessionId,
+    action,
+  );
 
   res.status(200).json({
     success: true,


### PR DESCRIPTION
## 개요
`validateId` 및 `checkStudyExists` 미들웨어를 통해 path parameter가 이미 숫자로 변환되고 있는데 focus controller에서 다시 숫자로 변환하는 중복 코드가 존재했습니다.
미들웨어에서 검증된 값을 그대로 사용하도록 수정하여 불필요한 변환 로직을 제거했습니다.

## 변경 사항
- focus controller sessionId Number 변환 제거
- 미들웨어에서 검증된 ID 값(req.params / req.studyId) 직접 사용

## 관련 이슈
- close #35
