### PR TITLE
feat: 스터디 목록 조회 API 구현

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -6,9 +6,9 @@ import {
 } from "../../errors/CustomError.js";
 
 export const getStudies = asyncHandler(async (req, res) => {
-  const { page, limit, keyword, sortBy, order } = req.qeury;
+  const { page, limit, keyword, sortBy, order } = req.qeury || {};
 
-  const data = await studyService.getStudies({
+  const result = await studyService.getStudies({
     page,
     limit,
     keyword,
@@ -16,7 +16,14 @@ export const getStudies = asyncHandler(async (req, res) => {
     order,
   });
 
-  res.status(200).json({ success: true, data: data.studies });
+  res
+    .status(200)
+    .json({
+      success: true,
+      data: result.data,
+      total: result.total,
+      has_more: result.has_more,
+    });
 });
 
 export const getStudyById = asyncHandler(async (req, res) => {

--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -6,7 +6,17 @@ import {
 } from "../../errors/CustomError.js";
 
 export const getStudies = asyncHandler(async (req, res) => {
-  res.status(200).json({ message: "TODO" });
+  const { page, limit, keyword, sortBy, order } = req.qeury;
+
+  const data = await studyService.getStudies({
+    page,
+    limit,
+    keyword,
+    sortBy,
+    order,
+  });
+
+  res.status(200).json({ success: true, data: data.studies });
 });
 
 export const getStudyById = asyncHandler(async (req, res) => {
@@ -24,7 +34,11 @@ export const createStudy = asyncHandler(async (req, res) => {
   if (!title || !theme || !password || !nickname) {
     throw new BadRequestError(
       "스터디 생성에 실패했습니다. 닉네임, 제목, 테마, 비밀번호는 필수입니다.",
-    );
+    ); //원래는 앞 문장만 정해뒀었는데 혹시모르니 뒤에 문장도 적어둠..
+    //이게 400에러를 반환하는데, 500에러는 알아서 처리되는 거겠지?
+    // asyncHandler 가 있어서 처리되는 방식인 거 같아요!
+    // asyncHandler 에서 성공이면 asyncHandler( 안에 작성된 함수 실행 )
+    // 실패면 next(err) 실행 < next(err) 은 express 약속
   }
 
   const createdStudy = await studyService.createStudy({

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -16,13 +16,25 @@ export const getStudies = async (data) => {
     where.OR = [{ title: { contains: keyword, mode: "insensitive" } }];
   }
 
+  /**
+   * 정렬 기준에 따라 응답해야할 데이터를 다르게 처리
+   * 포인트 기준을 정렬을 해야하는 경우 집중 테이블(focusSessions)의 필드 데이터(earnedPoint)의 합계로 이루어져야 하는 이슈
+   * 이 부분은 $queryRaw(?)를 이용해서 구현할 수 있다고는 하나 온전히 ai 가 짜준 코드를 복붙하는 수준밖에 안되는 상태라 용납할 수 없음
+   * $queryRaw 를 찾아보고 적용하는 것은 추후에 고려.
+   * 차선책으로는 study 테이블에 포인트합계 필드를 추가해서
+   * 포인트 획득시 study 테이블, focusSessions 테이블 두 곳을 컨트롤하는 방법도 있음.
+   *
+   * 결론:
+   * 포인트 기준 정렬 요청시 조회된 전체 데이터에서 배열을 포인트 정렬 기준에 맞게 가공 후 return
+   * 생성일시 기준 정렬 요청시 조회시 쿼리를 사용해서 데이터를 가져옴
+   */
   if (sortBy === "points") {
     const allStudiesRaw = await prisma.study.findMany({
       where,
       include: {
         focusSessions: {
           where: { status: "completed" },
-          select: { earnedPoints: true },
+          select: { earnedPoint: true },
         },
         emojis: true,
       },
@@ -30,23 +42,41 @@ export const getStudies = async (data) => {
 
     const allStudies = allStudiesRaw.map(({ focusSessions, ...rest }) => ({
       ...rest,
-      points: focusSessions.reduce((sum, s) => sum + s.earnedPoints, 0),
+      points: focusSessions.reduce((sum, s) => sum + s.earnedPoint, 0),
     }));
 
     allStudies.sort((a, b) =>
       order === "desc" ? b.points - a.points : a.points - b.points,
     );
+
+    const total = allStudies.length;
+    const studies = allStudies.slice(skip, skip + limit);
+    const has_more = skip + limit < total;
+
+    return { data: studies, total, has_more };
   }
 
-  const [studies, total] = await Promise.all([
+  const [studiesRaw, total] = await Promise.all([
     prisma.study.findMany({
       skip,
       take: limit,
       where,
       orderBy: { [sortBy]: order },
+      include: {
+        focusSessions: {
+          where: { status: "completed" },
+          select: { earnedPoint: true },
+        },
+        emojis: true,
+      },
     }),
     prisma.study.count({ where }),
   ]);
+
+  const studies = studiesRaw.map(({ focusSessions, ...rest }) => ({
+    ...rest,
+    points: focusSessions.reduce((sum, s) => sum + s.earnedPoint, 0),
+  }));
 
   const has_more = skip + limit < total;
 
@@ -88,7 +118,7 @@ export const getStudyById = async (id) => {
       focusSessions: {
         where: { status: "completed" },
         select: {
-          earnedPoints: true,
+          earnedPoint: true,
         },
       },
       emojis: true,

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -1,6 +1,61 @@
 import prisma from "../../lib/prisma.js";
 
-export const getStudies = async () => {};
+export const getStudies = async (data) => {
+  const page = Number(data.page) || 1; // 현재 페이지 초기 설정
+  const limit = Number(data.limit) || 6; // 페이지당 출력 수 초기 설정
+  const keyword = data.keyword || ""; // 검색 키워드
+  const sortBy = data.sortBy || "createdAt"; // 초기 정렬 기준 필드
+  const order = data.order || "desc"; // 초기 정렬 순서
+
+  const skip = (page - 1) * limit; // 건너뛸 수
+
+  const where = {};
+
+  if (keyword) {
+    // 스터디 제목에 검색키워드 포함된 데이터만
+    where.OR = [{ title: { contains: keyword, mode: "insensitive" } }];
+  }
+
+  if (sortBy === "points") {
+    const allStudiesRaw = await prisma.study.findMany({
+      where,
+      include: {
+        focusSessions: {
+          where: { status: "completed" },
+          select: { earnedPoints: true },
+        },
+        emojis: true,
+      },
+    });
+
+    const allStudies = allStudiesRaw.map(({ focusSessions, ...rest }) => ({
+      ...rest,
+      points: focusSessions.reduce((sum, s) => sum + s.earnedPoints, 0),
+    }));
+
+    allStudies.sort((a, b) =>
+      order === "desc" ? b.points - a.points : a.points - b.points,
+    );
+  }
+
+  const [studies, total] = await Promise.all([
+    prisma.study.findMany({
+      skip,
+      take: limit,
+      where,
+      orderBy: { [sortBy]: order },
+    }),
+    prisma.study.count({ where }),
+  ]);
+
+  const has_more = skip + limit < total;
+
+  return {
+    data: studies,
+    total,
+    has_more,
+  };
+};
 
 export const getStudyById = async (id) => {
   const today = new Date();
@@ -13,8 +68,8 @@ export const getStudyById = async (id) => {
   sunday.setDate(monday.getDate() + 6);
   sunday.setHours(23, 59, 59, 999);
 
-  const res = prisma.study.findUniqueOrThrow({
-    where: { id },
+  const res = await prisma.study.findUniqueOrThrow({
+    where: { id: id },
     omit: { password: true },
     include: {
       habits: {
@@ -33,7 +88,7 @@ export const getStudyById = async (id) => {
       focusSessions: {
         where: { status: "completed" },
         select: {
-          earnedPoint: true,
+          earnedPoints: true,
         },
       },
       emojis: true,


### PR DESCRIPTION
## 개요

검색기능: 
- keyword 쿼리 파라미터를 받아서 스터디 테이블의 title 에 keyword 가 포함된 데이터만 조회
---
정렬기능:
- 정렬 기준에 따라 조회 방식을 다르게 구현
> 생성일시 기준인 경우
> 스터디 테이블의 생성일시 필드(createdAt)를 기준으로 정렬된 데이터를 조회

> 포인트 기준인 경우
> 집중 테이블의 포인트 필드(earnedPoint)의 합계를 기준으로 스터디 테이블을 정렬하고 정렬된 데이터를 조회
---
더보기기능:
- page, limit 쿼리 파라미터를 받아서 skip 값을 계산하고, 스터디 테이블에서 skip, take 로 데이터를 끊어서 조회
---

## 변경 사항

study.controller.js
- getStudies 함수

study.service.js
- getStudies 함수

이전 스터디 상세 API 구현 중 await 빼먹은 부분도 추가

## 코드리뷰
- 조회를 원하는 테이블의 정렬 기준이 다른 테이블의 필드의 합계일 경우 어떤식으로 처리를 하는게 좋은지 궁금합니다!

## 관련 이슈

- close #17 
