### PR TITLE
fix: resume 시 endTime을 pausedAt 기준으로 재계산

### DIFF
--- a/src/modules/focus/focus.service.js
+++ b/src/modules/focus/focus.service.js
@@ -67,6 +67,8 @@ export const updateSession = async (studyId, id, status) => {
       studyId: true,
       status: true,
       durationMin: true,
+      endTime: true,
+      pausedAt: true,
     },
   });
 
@@ -87,10 +89,10 @@ export const updateSession = async (studyId, id, status) => {
 
   // running 상태일 때 현재시간 기준으로 종료 시간 재계산
   if (status === "running") {
-    const startTime = new Date();
-    data.endTime = new Date(
-      startTime.getTime() + focus.durationMin * 60 * 1000,
-    );
+    const remainingMs =
+      new Date(focus.endTime).getTime() - new Date(focus.pausedAt).getTime();
+
+    data.endTime = new Date(Date.now() + remainingMs);
   }
 
   const updateFocus = await prisma.FocusSession.update({


### PR DESCRIPTION
## 개요
집중 타이머의 pause 후 resume 시 남은 시간이 중지 시점 이후의 남은 시간이 아닌 초기 `durationMin` 기준으로 잘못 계산되던 문제를 수정했습니다.
기존에는 재시작 시점에서 `durationMin`을 기반으로 `endTime`을 다시 계산하여, pause 시점의 실제 남은 시간이 유지되지 않는 버그가 있었습니다.
그래서 `pausedAt`과 `endTime`을 기준으로 remaining time을 계산하여 pause → resume 시에도 타이머가 자연스럽게 이어지도록 개선했습니다.


## 변경 사항
- resume 시 endTime 계산 로직을 durationMin 기반 → remaining time 기반으로 변경
- pausedAt 및 endTime 필드를 Prisma 조회에 포함하도록 수정
- remaining time 계산 로직 추가
  - `endTime - pausedAt` 기준으로 남은 시간 계산
  - `Date.now() + remainingMs` 방식으로 재설정

## 영향 범위
- FocusSession 상태 변경 API (`PATCH /studies/:studyId/focus-sessions/:sessionId`)

## 관련 이슈
- close #41
