### PR TITLE
 fix: 집중 세션 조회 시 최신 진행 중인 세션이 반환되지 않는 버그 수정

### DIFF
--- a/src/modules/focus/focus.controller.js
+++ b/src/modules/focus/focus.controller.js
@@ -17,13 +17,6 @@ export const getSession = asyncHandler(async (req, res) => {
     });
   }
 
-  if (focus.status === "completed") {
-    return res.status(200).json({
-      success: true,
-      data: null,
-    });
-  }
-
   res.status(200).json({
     success: true,
     data: focus,

--- a/src/modules/focus/focus.service.js
+++ b/src/modules/focus/focus.service.js
@@ -1,10 +1,16 @@
 import prisma from "../../lib/prisma.js";
-import { StudyNotFoundError, ConflictError } from "../../errors/CustomError.js";
+import { ConflictError } from "../../errors/CustomError.js";
 
 export const getSession = async (studyId) => {
   const focus = await prisma.FocusSession.findFirst({
     where: {
       studyId,
+      status: {
+        in: ["running", "paused"],
+      },
+    },
+    orderBy: {
+      startTime: "desc",
     },
     select: {
       id: true,
@@ -19,10 +25,6 @@ export const getSession = async (studyId) => {
   });
 
   if (!focus) return null;
-
-  if (focus.status === "completed") {
-    return { status: "completed" };
-  }
 
   return focus;
 };


### PR DESCRIPTION
## 개요
스터디별 집중 타이머 조회 시 진행 중 세션이 반환되지 않거나, 완료된 세션이 반환되는 문제가 있어 이를 수정했습니다.
또한 컨트롤러에서 completed 상태를 직접 필터링해 조회 로직이 분산되고 일관성이 깨지는 문제가 있었습니다.
그래서 컨트롤러에서 completed 필터링 로직을 제거하고, 서비스 레이어에서 status 필터 및 orderBy를 추가해 최신 진행 중인 세션이 반환되도록 수정했습니다.

## 변경 사항
- 컨트롤러에서 completed 상태 필터링 로직 제거
- 서비스 레이어에서 status 조건 추가 (진행 중 세션만 조회)
- 최신 세션 1개 반환을 위한 `orderBy: { startTime: "desc" }` 추가
- 조회 로직을 서비스 레이어로 통합하여 책임 분리

## 영향 범위
- FocusSession 조회 API (`GET /studies/:studyId/focus-sessions`)
- 프론트엔드 타이머 초기 세션 로딩 로직

## 관련 이슈
- close #43
