### PR TITLE
feat: focus_sessions에 title 컬럼 추가

### DIFF
--- a/prisma/migrations/20260420083816_add_title_to_focus_session/migration.sql
+++ b/prisma/migrations/20260420083816_add_title_to_focus_session/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "focus_sessions" ADD COLUMN     "title" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model HabitLog {
 model FocusSession {
   id          Int         @id @default(autoincrement())
   studyId     Int         @map("study_id")
+  title       String?     @map("title")
   startTime   DateTime    @default(now()) @map("start_time")
   endTime     DateTime    @map("end_time")
   durationSec Int         @map("duration_sec") 


### PR DESCRIPTION
## 개요
현재 스터디별 세션을 1개로 제한하고 있어 여러 스터디원이 동시에 집중 타이머를 사용할 수 없는 문제가 있습니다.
띠라서 세션 생성 시 제목을 입력받아 각 세션을 식별할 수 있도록 하고자 합니다. 이를 위해 `focus_sessions`에 `title`컬럼을 추가했습니다.

## 변경 사항
- `focus_sessions`에 `title` 컬럼 추가


## 마이그레이션 안내
- PR merge 후 아래 명령어 실행 필요합니다!
```
npx prisma migrate deploy
npx prisma generate
````

## 영향 범위
- focus_sessions 테이블 컬럼 추가
- 집중 세션 생성/조회/수정 API 영향


## 관련 이슈

- close #60
