### PR TITLE
fix: 오늘 생성한 습관이 조회되지 않는 문제 수정

### DIFF
--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -43,7 +43,7 @@ export const createHabit = async (studyId, data) => {
     data: {
       studyId,
       habitName: habitName.trim(),
-      startAt: new Date(),
+      startAt: getTodayKST(),
     },
   });
 


### PR DESCRIPTION
## 개요

오늘 생성한 습관이 오늘의 습관 조회에서 보이지 않는 버그를 수정

## 변경 사항

createHabit에서 startAt을 new Date() → getTodayKST()로 변경

## 관련 이슈

- close #63 
