### PR TITLE
fix: habit 삭제 시 today 및 weekly 조회 제외 처리

### DIFF
--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -12,7 +12,7 @@ export const getTodayHabits = async (studyId) => {
     where: {
       studyId,
       startAt: { lte: today },
-      OR: [{ endAt: null }, { endAt: { gte: today } }],
+      OR: [{ endAt: null }, { endAt: { gt: today } }],
     },
     include: {
       habitLogs: {
@@ -203,7 +203,7 @@ export const deleteHabit = async (studyId, habitId) => {
       id: habitId,
     },
     data: {
-      endAt: new Date(),
+      endAt: getTodayKST(),
     },
   });
 };
@@ -241,7 +241,7 @@ export const getWeeklyLogs = async (studyId, date) => {
     where: {
       studyId,
       startAt: { lte: endDate },
-      OR: [{ endAt: null }, { endAt: { gte: startDate } }],
+      OR: [{ endAt: null }, { endAt: { gt: endDate } }],
     },
     orderBy: { createdAt: "asc" },
   });
@@ -292,7 +292,7 @@ export const getWeeklyLogs = async (studyId, date) => {
       logs: weekDates.map((dateStr) => {
         const isActive =
           habitStartDateStr <= dateStr &&
-          (habitEndDateStr === null || habitEndDateStr >= dateStr);
+          (habitEndDateStr === null || habitEndDateStr > dateStr);
 
         if (!isActive) {
           return {


### PR DESCRIPTION
## 개요

습관 삭제 시 today 조회와 주간 기록 조회에서 삭제한 습관이 계속 보이던 문제를 수정했습니다.

## 변경 사항

삭제 시 endAt을 KST 기준 날짜로 저장하도록 수정
today 조회 조건에서 삭제 당일 습관이 제외되도록 수정
주간 기록 조회에서 삭제한 습관 row 자체가 내려오지 않도록 수정

## 테스트

습관 생성 후 weekly 조회에 노출되는 것 확인
습관 삭제 후 today 조회에서 제외되는 것 확인
습관 삭제 후 weekly 조회에서 row 자체가 사라지는 것 확인

## 영향 범위

다른 기능에 영향이 있다면 작성해주세요. (API, DB, 공통 컴포넌트 변경 여부 등)

## 관련 이슈

- close #66 
