### PR TITLE
fix: today 조회 시 startAt 기준을 now로 수정하여 오늘 생성 습관 조회 문제 해결

### DIFF
--- a/src/modules/habit/habit.service.js
+++ b/src/modules/habit/habit.service.js
@@ -8,10 +8,12 @@ import { getTodayKST } from "../../common/utils/date.js";
 export const getTodayHabits = async (studyId) => {
   // 오늘 날짜 (시간 제거)
   const today = getTodayKST();
+  const now = new Date();
+
   const habits = await prisma.habit.findMany({
     where: {
       studyId,
-      startAt: { lte: today },
+      startAt: { lte: now },
       OR: [{ endAt: null }, { endAt: { gt: today } }],
     },
     include: {


### PR DESCRIPTION
## 개요

today 습관 조회 API에서 오늘 생성된 습관이 조회되지 않는 문제 수정
기존에는 `startAt <= today(00:00)` 기준으로 비교하여, 시간 정보가 포함된 오늘 생성 습관이 필터링되는 문제가 발생하여,
이를 `startAt <= now` 기준으로 변경하여, 현재 시각 기준으로 이미 시작된 습관이 정상적으로 조회되도록 수정.

## 변경 사항

- today 조회 시 `startAt` 비교 기준을 `today` → `now`로 수정
- 오늘 생성된 습관이 조회되지 않던 문제 해결


## 영향 범위

- 기존 습관 조회 및 체크/해제/삭제 기능에는 영향 없음

## 관련 이슈

- close #68 
