### PR TITLE
fix: 이모지 집계 후 response 처리 및 스터디 목록 검색 쿼리 수정

### DIFF
--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -1,5 +1,21 @@
 import prisma from "../../lib/prisma.js";
 
+const countedEmojis = (emojis, limit = null) => {
+  const countMap = {};
+  for (const { emoji } of emojis) {
+    countMap[emoji] = (countMap[emoji] || 0) + 1;
+  }
+
+  const sorted = Object.entries(countMap)
+    .map(([emoji, count]) => ({
+      emoji,
+      count,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  return limit ? sorted.slice(0, limit) : sorted;
+};
+
 export const getStudies = async (data) => {
   const page = Number(data.page) || 1; // 현재 페이지 초기 설정
   const limit = Number(data.limit) || 6; // 페이지당 출력 수 초기 설정
@@ -13,7 +29,11 @@ export const getStudies = async (data) => {
 
   if (keyword) {
     // 스터디 제목에 검색키워드 포함된 데이터만
-    where.OR = [{ title: { contains: keyword, mode: "insensitive" } }];
+    where.OR = [
+      { title: { contains: keyword, mode: "insensitive" } },
+      { nickname: { contains: keyword, mode: "insensitive" } },
+      { description: { contains: keyword, mode: "insensitive" } },
+    ];
   }
 
   /**
@@ -40,10 +60,13 @@ export const getStudies = async (data) => {
       },
     });
 
-    const allStudies = allStudiesRaw.map(({ focusSessions, ...rest }) => ({
-      ...rest,
-      points: focusSessions.reduce((sum, s) => sum + s.earnedPoint, 0),
-    }));
+    const allStudies = allStudiesRaw.map(
+      ({ focusSessions, emojis, ...rest }) => ({
+        ...rest,
+        points: focusSessions.reduce((sum, s) => sum + s.earnedPoint, 0),
+        emojis: countedEmojis(emojis, 3),
+      }),
+    );
 
     allStudies.sort((a, b) =>
       order === "desc" ? b.points - a.points : a.points - b.points,
@@ -73,9 +96,10 @@ export const getStudies = async (data) => {
     prisma.study.count({ where }),
   ]);
 
-  const studies = studiesRaw.map(({ focusSessions, ...rest }) => ({
+  const studies = studiesRaw.map(({ focusSessions, emojis, ...rest }) => ({
     ...rest,
     points: focusSessions.reduce((sum, s) => sum + s.earnedPoint, 0),
+    emojis: countedEmojis(emojis, 3),
   }));
 
   const has_more = skip + limit < total;
@@ -124,7 +148,7 @@ export const getStudyById = async (id) => {
           earnedPoint: true,
         },
       },
-      emojis: true,
+      // emojis: true,
     },
   });
 
@@ -171,7 +195,7 @@ export const getEmoji = async (studyId) => {
     where: { studyId },
   });
 
-  return res;
+  return countedEmojis(res);
 };
 
 export const addEmoji = async (studyId, emoji) => {


### PR DESCRIPTION
## 개요

- 이모지를 필요한 곳에 내보낼 때, 원하는 만큼 끊어서 내보낼 수 있게 countedEmojis 적용
- 스터디 목록 조회 검색시 검색어가 포함될 nickname, description 필드 추가

## 변경 사항

- getStudies: 스터디 전체 데이터를 response 시 이모지는 상위 3개만 걸러서 출력되게
- getStudyById: include 된 emojis 를 제거, 이모지 get, post 요청을 따로 하고 getStudyById 에서 include 로 가져올 경우 이 안에서도 처리를 해야한다고 함. 따로 분리해서 관리하는 방향으로 정리

## 관련 이슈

- close #73 
