### PR TITLE
fix: 스터디 상세 API 에 emojis 다시 추가

### DIFF
--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -148,11 +148,13 @@ export const getStudyById = async (id) => {
           earnedPoint: true,
         },
       },
-      // emojis: true,
+      emojis: true,
     },
   });
 
-  return res;
+  const emojis = countedEmojis(res.emojis, 3);
+
+  return { ...res, emojis };
 };
 
 export const createStudy = async (data) => {


### PR DESCRIPTION
## 개요

이모지 기능을 구현하면서 스터디 상세 조회 API 에서 include 해놨던 emojis 를 주석처리하고 getEmoji 로 클릭된 이모지들을 조회하도록 별도로 구현을 해놨는데, 스터디 상세 조회 API 에 emojis 를 안내보내주니 상세 페이지 접속시 로컬 스토리지에도 담기는 스터디 데이터에도 emojis 에 대한 데이터가 없어서 최근 조회한 스터디 UI 에 이모지 출력이 안되고 있는 이슈로 인해 스터디 상세 조회 API 에 emojis 를 다시 include 시킴

## 변경 사항

- getStudyById 에 emojis 를 다시 include


## 관련 이슈

- close #77 
