### PR TITLE
Feat: 최근 조회한 스터디 API 구현

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -24,6 +24,15 @@ export const getStudies = asyncHandler(async (req, res) => {
   });
 });
 
+export const getRecentStudies = asyncHandler(async (req, res) => {
+  const { ids } = req.query;
+  const idList = ids.split(",").map((id) => Number(id));
+
+  const result = await studyService.getRecentStudies(idList);
+
+  res.status(200).json({ success: true, data: result });
+});
+
 export const getStudyById = asyncHandler(async (req, res) => {
   const studyId = req.studyId;
 

--- a/src/modules/study/study.routes.js
+++ b/src/modules/study/study.routes.js
@@ -8,6 +8,7 @@ const router = express.Router();
 router.param("studyId", validateId);
 
 router.get("/", studyController.getStudies);
+router.get("/recent", studyController.getRecentStudies);
 router.post("/", studyController.createStudy);
 router.get("/:studyId", checkStudyExists, studyController.getStudyById);
 router.patch("/:studyId", checkStudyExists, studyController.updateStudy);

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -112,32 +112,31 @@ export const getStudies = async (data) => {
 };
 
 export const getRecentStudies = async (ids) => {
-  const res = await Promise.all(
-    ids.map(async (id) => {
-      const study = await prisma.study.findUniqueOrThrow({
-        where: { id },
-        omit: { password: true },
-        include: {
-          focusSessions: {
-            where: { status: "completed" },
-            select: {
-              earnedPoint: true,
-            },
-          },
-          emojis: true,
+  const studies = await prisma.study.findMany({
+    where: { id: { in: ids } },
+    omit: { password: true },
+    include: {
+      focusSessions: {
+        where: { status: "completed" },
+        select: {
+          earnedPoint: true,
         },
-      });
+      },
+      emojis: true,
+    },
+  });
 
-      const emojis = countedEmojis(study.emojis, 3);
+  const sorted = ids.map((id) => studies.find((study) => study.id === id));
 
-      const points = study.focusSessions.reduce(
-        (sum, s) => sum + s.earnedPoint,
-        0,
-      );
+  const res = sorted.map((study) => {
+    const emojis = countedEmojis(study.emojis, 3);
+    const points = study.focusSessions.reduce(
+      (sum, s) => sum + s.earnedPoint,
+      0,
+    );
 
-      return { ...study, points, emojis };
-    }),
-  );
+    return { ...study, points, emojis };
+  });
 
   return res;
 };

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -111,6 +111,37 @@ export const getStudies = async (data) => {
   };
 };
 
+export const getRecentStudies = async (ids) => {
+  const res = await Promise.all(
+    ids.map(async (id) => {
+      const study = await prisma.study.findUniqueOrThrow({
+        where: { id },
+        omit: { password: true },
+        include: {
+          focusSessions: {
+            where: { status: "completed" },
+            select: {
+              earnedPoint: true,
+            },
+          },
+          emojis: true,
+        },
+      });
+
+      const emojis = countedEmojis(study.emojis, 3);
+
+      const points = study.focusSessions.reduce(
+        (sum, s) => sum + s.earnedPoint,
+        0,
+      );
+
+      return { ...study, points, emojis };
+    }),
+  );
+
+  return res;
+};
+
 export const getStudyById = async (id) => {
   const today = new Date();
   const day = today.getDay(); // 오늘이 속한 요일(숫자로 받음)


### PR DESCRIPTION
## 개요

- 최근 조회한 스터디 API 구현
> 스터디 상세 페이지 접속해서 데이터를 불러온 후에 로컬스토리지에 담기다보니, 로컬스토리지에 담긴 이후에 발생한 액션( 응원 이모지 증가, 집중 페이지에서 획득한 포인트 )이 반영되지 않는 이슈가 발견되어 이모지 증가, 포인트 획득 시에 로컬스토리지를 업데이트 하는 방향으로 할지, 최근 조회 API 를 추가해서 로컬스토리지에는 studyId 만 담고 목록 페이지에서 로컬스토리지에 담긴 studyId 들을 가지고 조회된 데이터들을 전달 받을지 고민을 했고, id 만 저장하고 db에서 데이터를 넘겨받는게 최신화된 데이터를 가져와서 일관성 있는 데이터를 제공하는게 맞다고 생각이 되어 API 를 추가하게 됨

> 처음에는 쿼리로 전달받은 id 들로 조회한 데이터를 넘겨줄 때, Promise.all 로 순회를 했었는데 이러면 findUniqueOrThrow 를 최대 3번까지 호출해야하는 상황이 발생하는 것을 인지하고 Promise.all 은 제거하고 findMany 로 변경, where 절에 in 을 추가하는 쿼리로 변경해서 한번의 호출로 최대 3건의 데이터를 가져오는 방법으로 변경

## 변경 사항

- getRecentStudies 추가

## 관련 이슈

- close #79 
