### PR TITLE
fix: 스터디 목록 동일한 포인트 더보기 순서 이슈

### DIFF
--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -68,9 +68,17 @@ export const getStudies = async (data) => {
       }),
     );
 
-    allStudies.sort((a, b) =>
-      order === "desc" ? b.points - a.points : a.points - b.points,
-    );
+    allStudies.sort((a, b) => {
+      if (order === "desc") {
+        return b.points !== a.points
+          ? b.points - a.points
+          : new Date(a.createdAt) - new Date(b.createdAt);
+      } else {
+        return a.points !== b.points
+          ? a.points - b.points
+          : new Date(a.createdAt) - new Date(b.createdAt);
+      }
+    });
 
     const total = allStudies.length;
     const studies = allStudies.slice(skip, skip + limit);


### PR DESCRIPTION
## 개요

포인트 정렬 후 더보기 클릭해서 여러 스터디를 출력할 때,
동일한 포인트인 경우 출력되는 순서가 db 쿼리문을 돌렸을 때 순서와 상이함을 발견해서 수정

## 변경 사항

- getStudies 에서 포인트 정렬로 요청을 받은 경우 sort 처리로 데이터를 재정렬 후 내보내는데 sort 안에 포인트가 동일할 경우 createdAt 을 기준으로 정렬되게 포함시킴

## 스크린샷 (UI 변경 시)

<img width="634" height="207" alt="image" src="https://github.com/user-attachments/assets/aa7c019c-19b3-4355-8ac1-5e0e2f00d69e" />
👉 db 에서 쿼리를 돌려 출력된 데이터 정렬 순서 - 포인트 많은 순
<img width="1202" height="937" alt="image" src="https://github.com/user-attachments/assets/b32c07fe-8935-4551-b145-fb6c71ac89d1" />
👉 sort 수정 후 출력되는 스터디 목록 순서 - 포인트 많은 순

## 관련 이슈

- close #81 
