### PR TITLE
fix: ids 값이 빈값일 경우 빈배열 응답

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -26,9 +26,12 @@ export const getStudies = asyncHandler(async (req, res) => {
 
 export const getRecentStudies = asyncHandler(async (req, res) => {
   const { ids } = req.query;
-  const idList = ids.split(",").map((id) => Number(id));
+  let result = [];
 
-  const result = await studyService.getRecentStudies(idList);
+  if (ids) {
+    const idList = ids.split(",").map((id) => Number(id));
+    result = await studyService.getRecentStudies(idList);
+  }
 
   res.status(200).json({ success: true, data: result });
 });


### PR DESCRIPTION
## 개요

- 로컬스토리지 담긴 데이터가 빈값일 경우 ( ids= )
빈배열로 응답
데이터에 값이 존재하면 숫자배열로 변환 실행 후 데이터 조회

## 변경 사항

- 빈값을 전달 받은 경우 방어 로직 추가

## 스크린샷 (UI 변경 시)

UI가 변경된 경우 before / after 스크린샷을 첨부해주세요.

## 관련 이슈

- close #83 
