### PR TITLE
chore: 배포 환경 CORS 및 세션 설정 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -13,12 +13,25 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 8080;
 
+const allowedOrigins = [
+  "http://localhost:5173",
+  "https://forest-of-study.vercel.app",
+];
+
 app.use(
   cors({
-    origin: "http://localhost:5173", //TODO: 배포된 프론트 주소로 변경 필요. 일단 로컬 주소로 함
-    credentials: true, //반드시 true로 해야 프론트에서 쿠키를 받을 수 있음.
+    origin: function (origin, callback) {
+      // origin이 없거나(Postman 등) 목록에 있으면 허용
+      if (!origin || allowedOrigins.indexOf(origin) !== -1) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
   }),
 );
+
 app.use(express.json());
 
 /* 세션을 사용하기 위한 설정 */
@@ -29,7 +42,10 @@ app.use(
     saveUninitialized: false, // 초기화되지 않은 세션을 저장할지 여부 (보통 false 권장)
     cookie: {
       httpOnly: true, // 자바스크립트로 쿠키 접근 방지 (보안!)
-      secure: false, // 배포 전(HTTP)에는 false로 설정
+      // 배포 환경(production)일 때는 secure를 true로 (HTTPS 적용)
+      secure: process.env.NODE_ENV === "production",
+      // 배포 환경에서는 크로스 도메인 쿠키 전달을 위해 아래 설정이 필요할 수 있음
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
       maxAge: 1000 * 60 * 60, // 쿠키 유효 시간 (현재 1시간 설정)
     },
   }),


### PR DESCRIPTION
## 개요
로컬 환경뿐만 아니라 Vercel 배포 환경에서도 백엔드 API와 통신할 수 있도록 CORS(Cross-Origin Resource Sharing) 설정 을 수정했습니다.

## 변경 사항
- CORS 도메인 허용: allowedOrigins 배열을 생성하여 로컬 주소(localhost:5173)와 Vercel 프로덕션 주소(https://forest-of-study.vercel.app)를 모두 허용하도록 수정했습니다.
- 세션 쿠키 보안 설정: NODE_ENV 환경 변수에 따라 배포 환경(production)일 경우 secure: true 및 sameSite: "none" 옵션이 적용되도록 분기 처리했습니다.
- 환경 변수 대응: 하드코딩된 설정 대신 process.env.NODE_ENV를 활용하여 개발/운영 환경에 유연하게 대응하도록 개선했습니다.

## 영향 범위
- API/공통: 모든 API 요청의 허용 범위가 변경됨. 이제 Vercel 도메인에서의 요청을 서버가 수용함

## 관련 이슈
- close #85
