### PR TITLE
fix: Render 프록시 환경에서 세션 쿠키 미설정 문제 해결

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,8 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 8080;
 
+app.set("trust proxy", 1);
+
 const allowedOrigins = [
   "http://localhost:5173",
   "https://forest-of-study.vercel.app",


### PR DESCRIPTION
## 개요
Render 배포 환경에서 비밀번호 인증 후 세션 확인 시 401 Unauthorized 에러가 발생했습니다.
Render는 프록시 뒤에서 동작하여 Node.js 앱이 요청을 HTTP로 인식, `secure: true` 쿠키가 정상 발급되지 않는 것이 원인이었습니다.
따라서 Express의 `trust proxy` 설정을 활성화하여 Render 프록시를 거친 요청도 HTTPS 요청으로 올바르게 인식하도록 처리했습니다.

## 변경 사항
- `server.js`에 `app.set('trust proxy', 1)` 추가

## 관련 이슈
- close #87
- 해결된 줄 알았으나 Chrome 서드파티 쿠키 차단으로 미해결된 상태 → 최종 해결 #93 