### PR TITLE
fix: DB 세션 저장소 도입 시도 (근본 원인 아님을 확인)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,15 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
+        "connect-pg-simple": "^10.0.0",
         "cors": "^2.8.6",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
         "express-session": "^1.19.0",
-        "pg": "^8.20.0"
+        "pg": "^8.20.0",
+        "render": "^0.1.4"
       },
       "devDependencies": {
         "nodemon": "^3.1.14",
@@ -29,8 +31,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -737,6 +738,18 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/connect-pg-simple": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
+      "integrity": "sha512-pBGVazlqiMrackzCr0eKhn4LO5trJXsOX0nQoey9wCOayh80MYtThCbq8eoLsjpiWgiok/h+1/uti9/2/Una8A==",
+      "license": "MIT",
+      "dependencies": {
+        "pg": "^8.12.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
+      }
+    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -824,14 +837,22 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/curry": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/curry/-/curry-0.0.4.tgz",
+      "integrity": "sha512-IPapCjuLQfb9u7HEU+l7XX10CmK5ojdvjt+0sNrZmSvSU31OZxPV78cmDj1Zm+ZX/tEh7jeYdaD4v89iJDOD0g==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1418,7 +1439,6 @@
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1929,7 +1949,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2108,7 +2127,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.6.0",
         "@prisma/dev": "0.24.3",
@@ -2300,6 +2318,15 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
+    "node_modules/render": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/render/-/render-0.1.4.tgz",
+      "integrity": "sha512-mTNCTWXyulJhMFcsCZGwMjE3GjH40eE4r23Or7Sw4XnEBHO8gS5ZBHgxDGjFF1v0pe9GXx+c+8njbpry+11e3A==",
+      "license": "MIT",
+      "dependencies": {
+        "traverser": "0.0.x"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2367,7 +2394,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -2648,6 +2676,17 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/traverser": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
+      "integrity": "sha512-8wq1H/gNr1PwGhmflklBTvZlY3aOgUmurSYD8PueKn1Btq01REtupQ8nY7VpcG4v2YPKBODxYKIdTt36W+Scwg==",
+      "dependencies": {
+        "curry": "0.0.x"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
+    "connect-pg-simple": "^10.0.0",
     "cors": "^2.8.6",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
     "express-session": "^1.19.0",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "render": "^0.1.4"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/src/server.js
+++ b/src/server.js
@@ -7,11 +7,13 @@ import habitLogRouter from "./modules/habit/habit-log.routes.js";
 import focusRouter from "./modules/focus/focus.routes.js";
 import errorHandler from "./common/middlewares/errorHandler.js";
 import session from "express-session";
+import connectPgSimple from "connect-pg-simple";
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 8080;
+const PgSession = connectPgSimple(session);
 
 app.set("trust proxy", 1);
 
@@ -39,6 +41,11 @@ app.use(express.json());
 /* 세션을 사용하기 위한 설정 */
 app.use(
   session({
+    store: new PgSession({
+      // 추가
+      conString: process.env.DATABASE_URL, // 추가
+      tableName: "session", // 추가
+    }),
     secret: process.env.SESSION_SECRET || "part2-team3-key", // 세션 암호화 키
     resave: false, // 세션 수정사항이 없어도 다시 저장할지 여부
     saveUninitialized: false, // 초기화되지 않은 세션을 저장할지 여부 (보통 false 권장)


### PR DESCRIPTION
## 개요
배포 환경에서 기존의 세션 기반 인증 방식이 제대로 동작하지 않는 문제가 있었습니다.
Render 로그에서 `MemoryStore` 경고가 떠서 이것이 세션 인증 실패의 원인이라 판단해, DB 세션 저장소로 변경을 시도했습니다.

## 변경사항
- `connect-pg-simple` 설치
- `server.js` 세션 store를 PostgreSQL로 변경
- DB에 session 테이블 생성

## 결과
이는 근본적인 해결책이 아니었습니다.
MemoryStore는 서버 재시작 시 세션이 날아가는 문제이고, 실제 원인은 Chrome 147의 서드파티 쿠키 차단으로 인해 쿠키 자체가 요청에 포함되지 않는 것이었습니다.
따라서 #90에서 다른 방식으로 해결했습니다.
 
