### PR TITLE
fix: 세션 기반 인증 방식을 localStorage 토큰으로 전환

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -116,19 +116,32 @@ export const verifyPassword = asyncHandler(async (req, res) => {
   if (!req.session.authorizedStudies.includes(studyId)) {
     req.session.authorizedStudies.push(studyId);
   }
-  res
-    .status(200)
-    .json({ success: true, data: { session: req.session.authorizedStudies } }); //현재 세션에 어떤 스터디 id가 들어있는지도 함께 응답으로 보냄.
+  res.status(200).json({
+    success: true,
+    data: {
+      session: req.session.authorizedStudies,
+      sessionId: req.sessionID, // 추가
+    },
+  });
+  //현재 세션에 어떤 스터디 id가 들어있는지도 함께 응답으로 보냄.
 });
 
 //세션에 있는 스터디 id인지 점검
 export const checkSession = asyncHandler(async (req, res) => {
-  const studyId = req.studyId;
-  const isAuthorized = req.session.authorizedStudies?.includes(studyId);
-  if (!isAuthorized) {
-    //세션에 없는 스터디 id 일시, 에러를 리턴한다. (그런데 그냥 응답으로 주는 게 프론트가 편하다는데, 뭐가 좋을까?)
+  const sessionId = req.headers["x-session-id"];
+
+  // 세션이 없으면 실패
+  if (!sessionId) {
     throw new AuthenticationError();
   }
+
+  // express-session이 이미 req.session에 복원 못하는 상황 대비 fallback
+  const isAuthorized = req.session?.authorizedStudies?.includes(studyId);
+
+  if (!isAuthorized) {
+    throw new AuthenticationError();
+  }
+
   res.status(200).json({ success: true });
 });
 

--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -128,6 +128,8 @@ export const verifyPassword = asyncHandler(async (req, res) => {
 
 //세션에 있는 스터디 id인지 점검
 export const checkSession = asyncHandler(async (req, res) => {
+  const studyId = req.studyId;
+
   const sessionId = req.headers["x-session-id"];
 
   // 세션이 없으면 실패


### PR DESCRIPTION
## 개요
Chrome 147부터 서드파티 쿠키를 강하게 차단하면서 배포 환경(크로스 도메인: Vercel ↔ Render) 기존 세션 인증 방식이 동작하지 않았습니다.
이를 해결하기 위해 DB 세션 저장소로 변경했으나, 이는 근본적인 해결책이 아니었습니다. (#89)
따라서 세션ID를 비밀번호 인증 api의 응답으로 포함하고, 세션 검증 api에서는 헤더로 세션ID를 전송받는 방식으로 변경했습니다.

## 변경사항
- `verifyPassword`: 응답에 `sessionId` 추가
- `checkSession`:  `x-session-id` 헤더로 `sessionId`를 받아 처리

## 
