### PR TITLE
fix: sessionId에 studyId 포함하여 인증 검증 강화

### DIFF
--- a/src/modules/study/study.controller.js
+++ b/src/modules/study/study.controller.js
@@ -108,10 +108,11 @@ export const verifyPassword = asyncHandler(async (req, res) => {
     throw new BadRequestError("비밀번호가 올바르지 않습니다.");
   }
 
+  //  sessionId에 studyId 포함
   res.status(200).json({
     success: true,
     data: {
-      sessionId: "temp-" + Date.now(),
+      sessionId: `${Date.now()}-${studyId}`,
     },
   });
 });
@@ -119,14 +120,18 @@ export const verifyPassword = asyncHandler(async (req, res) => {
 //세션에 있는 스터디 id인지 점검
 export const checkSession = asyncHandler(async (req, res) => {
   const studyId = req.studyId;
-
   const sessionId = req.headers["x-session-id"];
 
   if (!sessionId) {
     throw new AuthenticationError();
   }
 
-  // 임시 방식: sessionId 존재하면 인증된 것으로 간주
+  // localStorage에 저장된 값이 해당 studyId를 포함하는지 확인
+  const authorizedStudyId = Number(sessionId.split("-")[1]);
+  if (authorizedStudyId !== studyId) {
+    throw new AuthenticationError();
+  }
+
   res.status(200).json({ success: true });
 });
 


### PR DESCRIPTION
## 개요
#91에서 sessionId 존재 여부만 확인해 어떤 값이든 인증이 통과되는 보안 문제가 있었습니다.
sessionId에 studyId를 포함시켜 해당 스터디에 인증된 경우만 통과하도록 수정했습니다.

## 변경 사항
- sessionId 형식을 `temp-timestamp` → `timestamp-studyId`로 변경
- checkSession에서 sessionId의 studyId 추출 후 검증 로직 추가

## 전체 변경 과정 요약
- #88: trust proxy 추가 → Chrome 서드파티 쿠키 차단으로 미해결
- #89: DB 세션 저장소 도입 시도 → 근본 원인 아님을 확인
- #90: localStorage + x-session-id 헤더 방식으로 전환
- #91: #90 미완성 인증 로직 마무리
- #93: sessionId 검증 강화 (현재 PR)

## 관련 이슈
- close #94
- 해당 트러블슈팅은 노션에 정리해두었습니다: https://www.notion.so/Render-Vercel-34a7c51d9128806ba768fa2b10acd461
