### PR TITLE
chore: connect-pg-simple 제거 및 세션 미들웨어 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,11 @@
       "dependencies": {
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
-        "connect-pg-simple": "^10.0.0",
         "cors": "^2.8.6",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
-        "express-session": "^1.19.0",
         "pg": "^8.20.0",
         "render": "^0.1.4"
       },
@@ -738,18 +736,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/connect-pg-simple": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
-      "integrity": "sha512-pBGVazlqiMrackzCr0eKhn4LO5trJXsOX0nQoey9wCOayh80MYtThCbq8eoLsjpiWgiok/h+1/uti9/2/Una8A==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
-      }
-    },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -1089,50 +1075,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/express-session": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
-      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "~0.7.2",
-        "cookie-signature": "~1.0.7",
-        "debug": "~2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.1.0",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "~5.2.1",
-        "uid-safe": "~2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/express-session/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express-session/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -1883,15 +1825,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/on-headers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2225,15 +2158,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2362,26 +2286,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2701,18 +2605,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "license": "MIT",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -14,15 +14,12 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
-    "connect-pg-simple": "^10.0.0",
     "cors": "^2.8.6",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
-    "express-session": "^1.19.0",
-    "pg": "^8.20.0",
-    "render": "^0.1.4"
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/src/server.js
+++ b/src/server.js
@@ -6,14 +6,11 @@ import habitRouter from "./modules/habit/habit.routes.js";
 import habitLogRouter from "./modules/habit/habit-log.routes.js";
 import focusRouter from "./modules/focus/focus.routes.js";
 import errorHandler from "./common/middlewares/errorHandler.js";
-import session from "express-session";
-import connectPgSimple from "connect-pg-simple";
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 8080;
-const PgSession = connectPgSimple(session);
 
 app.set("trust proxy", 1);
 
@@ -38,28 +35,6 @@ app.use(
 
 app.use(express.json());
 
-/* 세션을 사용하기 위한 설정 */
-app.use(
-  session({
-    store: new PgSession({
-      // 추가
-      conString: process.env.DATABASE_URL, // 추가
-      tableName: "session", // 추가
-    }),
-    secret: process.env.SESSION_SECRET || "part2-team3-key", // 세션 암호화 키
-    resave: false, // 세션 수정사항이 없어도 다시 저장할지 여부
-    saveUninitialized: false, // 초기화되지 않은 세션을 저장할지 여부 (보통 false 권장)
-    cookie: {
-      httpOnly: true, // 자바스크립트로 쿠키 접근 방지 (보안!)
-      // 배포 환경(production)일 때는 secure를 true로 (HTTPS 적용)
-      secure: process.env.NODE_ENV === "production",
-      // 배포 환경에서는 크로스 도메인 쿠키 전달을 위해 아래 설정이 필요할 수 있음
-      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-      maxAge: 1000 * 60 * 60, // 쿠키 유효 시간 (현재 1시간 설정)
-    },
-  }),
-);
-
 app.use("/studies", studyRouter);
 app.use("/studies/:studyId/habits", habitRouter);
 app.use("/studies/:studyId/habit-logs", habitLogRouter);
@@ -69,5 +44,4 @@ app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
-  console.log(`NODE_ENV: ${process.env.NODE_ENV}`); // 추가
 });


### PR DESCRIPTION
## 개요
localStorage + x-session-id 헤더 방식으로 전환하면서 더 이상 사용하지 않는 세션 관련 코드를 제거했습니다.

## 변경 사항
- `connect-pg-simple` 패키지 제거 (`npm uninstall connect-pg-simple`)
- `server.js`에서 `session`, `connectPgSimple` import 삭제
- `server.js`에서 세션 미들웨어 전체 삭제

## 영향 범위
- 의존성이 변경되었으므로 `npm install` 필수