### PR TITLE
fix: 최근 조회한 스터디 목록 중 삭제된 스터디가 있는 경우 제외하고 응답

### DIFF
--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -134,7 +134,9 @@ export const getRecentStudies = async (ids) => {
     },
   });
 
-  const sorted = ids.map((id) => studies.find((study) => study.id === id));
+  const sorted = ids
+    .map((id) => studies.find((study) => study.id === id))
+    .filter((study) => Boolean(study));
 
   const res = sorted.map((study) => {
     const emojis = countedEmojis(study.emojis, 3);


### PR DESCRIPTION
## 개요

최근 조회한 스터디를 담는 로컬스토리지에 삭제한 스터디id 가 포함되어 있는 경우 조회되지 않는 데이터는 제외하고 응답

## 변경 사항

- getRecentStudies 에서 로컬스토리지에 담긴 순서로 재정렬하는 `sorted` 부분에 `filter((study) => Boolean(study));` 추가해서 데이터가 존재하는 경우에만 응답

## 관련 이슈

- close #96 
