### PR TITLE
fix: KST로 인해 9시간 차이나는 이슈 Z -> +09:00로 변경

### DIFF
--- a/src/common/utils/date.js
+++ b/src/common/utils/date.js
@@ -2,5 +2,5 @@ import { formatInTimeZone } from "date-fns-tz";
 
 export const getTodayKST = () => {
   const dateStr = formatInTimeZone(new Date(), "Asia/Seoul", "yyyy-MM-dd");
-  return new Date(`${dateStr}T00:00:00.000Z`);
+  return new Date(`${dateStr}T00:00:00+09:00`);
 };

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -1,4 +1,5 @@
 import prisma from "../../lib/prisma.js";
+import { getTodayKST } from "../../common/utils/date.js";
 
 const countedEmojis = (emojis, limit = null) => {
   const countMap = {};
@@ -152,15 +153,16 @@ export const getRecentStudies = async (ids) => {
 };
 
 export const getStudyById = async (id) => {
-  const today = new Date();
-  const day = today.getDay(); // 오늘이 속한 요일(숫자로 받음)
-  const monday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 월요일을 구함
-  monday.setDate(today.getDate() - (day === 0 ? 6 : day - 1));
-  monday.setHours(0, 0, 0, 0);
+  // KST 기준 오늘 자정 (UTC로 저장된 값, e.g. 2026-04-26T15:00:00.000Z = KST 2026-04-27 00:00)
+  const todayKST = getTodayKST();
+  // KST 요일 계산: UTC 시간에 9시간 더해 KST 날짜 기준 요일 구함
+  const kstDayOfWeek = new Date(todayKST.getTime() + 9 * 60 * 60 * 1000).getUTCDay();
+  const daysFromMonday = kstDayOfWeek === 0 ? 6 : kstDayOfWeek - 1;
 
-  const sunday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 일요일을 구함
-  sunday.setDate(monday.getDate() + 6);
-  sunday.setHours(23, 59, 59, 999);
+  // KST 이번 주 월요일 자정 (UTC)
+  const monday = new Date(todayKST.getTime() - daysFromMonday * 24 * 60 * 60 * 1000);
+  // KST 이번 주 일요일 끝 (UTC) = 월요일 + 7일 - 1ms
+  const sunday = new Date(monday.getTime() + 7 * 24 * 60 * 60 * 1000 - 1);
 
   const res = await prisma.study.findUniqueOrThrow({
     where: { id },


### PR DESCRIPTION
## 개요

KST로 인해 9시간 시간 차이나는 것 해결

## 변경 사항

시간 계산 로직 변경
data.js에서 Z 대신 +09:00

## 스크린샷
<img width="1445" height="241" alt="image" src="https://github.com/user-attachments/assets/4a3547a5-6ffa-434e-a831-d9c8d8fd0c0c" />

- close #103 
