### PR TITLE
fix: 시간대 불일치로 인한 습관 조회 및 체크 여부 저장 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "date-fns-tz": "^3.2.0",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
-        "pg": "^8.20.0",
-        "render": "^0.1.4"
+        "pg": "^8.20.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.14",
@@ -825,14 +824,6 @@
       "devOptional": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/curry": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/curry/-/curry-0.0.4.tgz",
-      "integrity": "sha512-IPapCjuLQfb9u7HEU+l7XX10CmK5ojdvjt+0sNrZmSvSU31OZxPV78cmDj1Zm+ZX/tEh7jeYdaD4v89iJDOD0g==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -2242,15 +2233,6 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
-    "node_modules/render": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/render/-/render-0.1.4.tgz",
-      "integrity": "sha512-mTNCTWXyulJhMFcsCZGwMjE3GjH40eE4r23Or7Sw4XnEBHO8gS5ZBHgxDGjFF1v0pe9GXx+c+8njbpry+11e3A==",
-      "license": "MIT",
-      "dependencies": {
-        "traverser": "0.0.x"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2580,17 +2562,6 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
-      }
-    },
-    "node_modules/traverser": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/traverser/-/traverser-0.0.5.tgz",
-      "integrity": "sha512-8wq1H/gNr1PwGhmflklBTvZlY3aOgUmurSYD8PueKn1Btq01REtupQ8nY7VpcG4v2YPKBODxYKIdTt36W+Scwg==",
-      "dependencies": {
-        "curry": "0.0.x"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-is": {

--- a/src/common/utils/date.js
+++ b/src/common/utils/date.js
@@ -1,6 +1,7 @@
 import { formatInTimeZone } from "date-fns-tz";
 
 export const getTodayKST = () => {
+  // KST 날짜를 구하되, DB @db.Date가 UTC 자정으로 저장하므로 UTC 자정으로 반환
   const dateStr = formatInTimeZone(new Date(), "Asia/Seoul", "yyyy-MM-dd");
   return new Date(`${dateStr}T00:00:00.000Z`);
 };

--- a/src/modules/study/study.service.js
+++ b/src/modules/study/study.service.js
@@ -1,5 +1,5 @@
 import prisma from "../../lib/prisma.js";
-import { getTodayKST } from "../../common/utils/date.js";
+import { formatInTimeZone } from "date-fns-tz";
 
 const countedEmojis = (emojis, limit = null) => {
   const countMap = {};
@@ -153,15 +153,19 @@ export const getRecentStudies = async (ids) => {
 };
 
 export const getStudyById = async (id) => {
-  const today = new Date();
-  const day = today.getDay(); // 오늘이 속한 요일(숫자로 받음)
-  const monday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 월요일을 구함
-  monday.setDate(today.getDate() - (day === 0 ? 6 : day - 1));
-  monday.setHours(0, 0, 0, 0);
+  // KST 기준 오늘 날짜 문자열
+  const todayStr = formatInTimeZone(new Date(), "Asia/Seoul", "yyyy-MM-dd");
 
-  const sunday = new Date(today); // 오늘 날짜를 기준으로 이번 주의 일요일을 구함
-  sunday.setDate(monday.getDate() + 6);
-  sunday.setHours(23, 59, 59, 999);
+  // DB의 @db.Date는 UTC 자정으로 저장되므로 UTC 자정 기준으로 맞추기
+  const today = new Date(`${todayStr}T00:00:00.000Z`);
+
+  const day = today.getUTCDay();
+  const monday = new Date(today);
+  monday.setUTCDate(today.getUTCDate() - (day === 0 ? 6 : day - 1));
+
+  const sundayEnd = new Date(monday);
+  sundayEnd.setUTCDate(monday.getUTCDate() + 6);
+  sundayEnd.setUTCHours(23, 59, 59, 999);
 
   const res = await prisma.study.findUniqueOrThrow({
     where: { id },
@@ -177,7 +181,7 @@ export const getStudyById = async (id) => {
             where: {
               logDate: {
                 gte: monday,
-                lte: sunday,
+                lte: sundayEnd,
               },
             },
           },


### PR DESCRIPTION
## 개요
KST 새벽 시간대(자정~오전 9시)에 습관이 조회되지 않으며,
습관 체크 시 logDate가 하루 어긋나게 저장되는 문제를 수정했습니다.

## 원인
1. getTodayKST()가 UTC 자정(T00:00:00.000Z)을 반환 → KST 오전 9시 이전에는 startAt > now 조건 탈락으로 빈 배열 반환
2. KST 자정(+09:00)으로 수정했으나 @db.Date가 UTC 날짜만 추출 → KST 자정을 넣으면 UTC 기준 전날 날짜로 저장됨

## 해결
KST 날짜 문자열을 먼저 구한 뒤 UTC 자정으로 변환하는 방식으로 통일
→ @db.Date의 UTC 날짜 추출과 KST 날짜 기준이 일치하게 됨

## 변경 사항
- common/utils/date.js: getTodayKST()를 KST 날짜 문자열 기준 + UTC 자정으로 변경
- study/study.service.js: getStudyById()의 주간 범위 계산도 동일 기준으로 수정

## 영향 범위
- getTodayKST() 수정
- date-fns-tz 설치 필요 (KST 기준 날짜 문자열을 구하기 위해 사용)

## 관련 이슈

- close #109
